### PR TITLE
fix: resolve 10 dead links across documentation guides

### DIFF
--- a/docs/guides/how-to-deliver-wave-step-scenario-mapping.md
+++ b/docs/guides/how-to-deliver-wave-step-scenario-mapping.md
@@ -2,7 +2,7 @@
 
 **Document Type**: How-to Guide
 **Last Updated**: 2026-01-24
-**Related**: [Outside-In TDD: Step-to-Scenario Mapping Principle](../reference/step-template-mapped-scenario-field.md)
+**Related**: Outside-In TDD: Step-to-Scenario Mapping Principle
 
 ## Goal
 
@@ -179,7 +179,7 @@ Before declaring DELIVER wave complete:
 3. Reduce roadmap to match scenario count
 4. Mark infrastructure steps as type `infrastructure` (not feature)
 
-**Reference**: [Outside-In TDD: Step-to-Scenario Mapping Principle](../reference/step-template-mapped-scenario-field.md)
+**Reference**: See the Step-to-Scenario Mapping sections above
 
 ### Issue: Multiple Scenarios Pass in One Step
 **Problem**: Step 01-01 makes tests 1, 2, and 3 pass instead of just test 1.
@@ -201,9 +201,7 @@ Before declaring DELIVER wave complete:
 
 ## Related Documentation
 
-- **Principle**: [Outside-In TDD: Step-to-Scenario Mapping](../reference/step-template-mapped-scenario-field.md) - Understand the discipline behind step-to-scenario mapping
-- **Reference**: [Step Template Mapped Scenario Field](../reference/step-template-mapped-scenario-field.md) - Full schema specification for mapping fields
-- **Reference**: [nWave Commands Reference](../reference/nwave-commands-reference.md) - Complete command specifications
+- **Reference**: [nWave Commands Reference](../reference/commands/index.md) - Complete command specifications
 - **Agent Specification**: See `~/.claude/agents/nw/solution-architect.md` for step generation details
 
 ---

--- a/docs/guides/invoke-reviewer-agents.md
+++ b/docs/guides/invoke-reviewer-agents.md
@@ -9,8 +9,8 @@ Step-by-step guide to requesting peer reviews from reviewer agents.
 **Prerequisites**: Familiarity with Task tool and wave workflows.
 
 **Related Docs**:
-- [Reviewer Agents Reference](../reference/reviewer-agents-reference.md) (lookup)
-- [Reviewer Agents Reference](../reference/reviewer-agents-reference.md) (reference)
+- [Reviewer Agents Reference](../reference/agents/index.md) (lookup)
+- [Reviewer Agents Reference](../reference/agents/index.md) (reference)
 
 ---
 

--- a/docs/guides/jobs-to-be-done-guide.md
+++ b/docs/guides/jobs-to-be-done-guide.md
@@ -350,7 +350,7 @@ Skip early waves when:
 
 ## Agent Selection
 
-For complete agent specifications and selection guidance, see the [nWave Commands Reference](../reference/nwave-commands-reference.md).
+For complete agent specifications and selection guidance, see the [nWave Commands Reference](../reference/commands/index.md).
 
 **Quick Overview**:
 - **Core Wave Agents**: product-discoverer, product-owner, solution-architect, platform-architect, acceptance-designer, software-crafter
@@ -432,4 +432,4 @@ For complete agent specifications and selection guidance, see the [nWave Command
 
 ## Command and File Reference
 
-For complete command specifications, agent selection, and file locations, see the [nWave Commands Reference](../reference/nwave-commands-reference.md).
+For complete command specifications, agent selection, and file locations, see the [nWave Commands Reference](../reference/commands/index.md).

--- a/docs/guides/tutorial-hello-nwave.md
+++ b/docs/guides/tutorial-hello-nwave.md
@@ -124,4 +124,4 @@ The feature is tested, committed, and ready to use.
 
 - **Bigger feature**: See [Your First Feature](./tutorial-first-feature.md) for a multi-phase workflow with architecture design
 - **Existing codebase**: See [Jobs To Be Done Guide](./jobs-to-be-done-guide.md) for adding features to brownfield projects
-- **All commands**: See [nWave Commands Reference](../reference/nwave-commands-reference.md)
+- **All commands**: See [nWave Commands Reference](../reference/commands/index.md)


### PR DESCRIPTION
Three non-existent reference targets were linked from four guide files:
- nwave-commands-reference.md → commands/index.md (4 occurrences)
- reviewer-agents-reference.md → agents/index.md (2 occurrences)
- step-template-mapped-scenario-field.md → removed (no equivalent exists, 4 occurrences)