### PR TITLE
fix(installer): preserve user PATH on fresh install instead of stripping it

### DIFF
--- a/scripts/install/plugins/des_plugin.py
+++ b/scripts/install/plugins/des_plugin.py
@@ -1,6 +1,7 @@
 """DES (Deterministic Execution System) installation plugin."""
 
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -36,10 +37,12 @@ class DESPlugin(InstallationPlugin):
         "des-health-check",
     ]
 
-    # Minimal POSIX system directories written as fallback when settings.json
-    # has no prior env.PATH. Claude Code REPLACES env.PATH entirely (no merge
-    # with the inherited shell PATH), so omitting these makes system tools
-    # (python3, grep, git) unreachable by bare name after install.
+    # Minimal POSIX system directories written as a last-resort fallback when
+    # settings.json has no prior env.PATH AND os.environ has no PATH at install
+    # time (highly unusual). Claude Code REPLACES env.PATH entirely (no merge
+    # with the inherited shell PATH), so on the normal path the installer
+    # seeds env.PATH from os.environ["PATH"] to preserve user-visible
+    # directories (~/.local/bin, ~/.deno/bin, /snap/bin, etc.).
     SYSTEM_PATH_FALLBACK = "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
     # DES templates installed to ~/.claude/templates/
@@ -883,6 +886,20 @@ class DESPlugin(InstallationPlugin):
         Idempotent: skips prepend if des_bin_path is already a colon-delimited
         segment of the current PATH value.
 
+        When settings.json has no prior env.PATH, seeds it from the live
+        install-time PATH (os.environ["PATH"]) so user-visible directories
+        (~/.local/bin, ~/.deno/bin, ~/.cargo/bin, /snap/bin, ~/bin, etc.)
+        remain reachable. Claude Code REPLACES env.PATH (it does not merge
+        with the inherited shell PATH), so seeding from a hardcoded minimum
+        would strip the user's real PATH. Falls back to SYSTEM_PATH_FALLBACK
+        only when os.environ has no PATH (highly unusual).
+
+        Auto-heals settings written by older installer versions whose PATH
+        equals exactly '<des_bin>:<SYSTEM_PATH_FALLBACK>': those values
+        replaced the user's real PATH and broke bare-name resolution of
+        binaries in ~/.local/bin (where pipx-installed CLIs live, including
+        claude and nwave-ai itself).
+
         Normalizes pre-existing $HOME entries to absolute paths. Claude Code passes
         env.PATH verbatim to exec() without shell expansion, so $HOME literals never
         resolve to the actual filesystem directory. Re-running install on a settings.json
@@ -907,6 +924,20 @@ class DESPlugin(InstallationPlugin):
             segments = [s.replace("$HOME", home) for s in existing_path.split(":")]
             existing_path = ":".join(segments)
 
+        # Auto-heal settings written by older installer versions: detect the
+        # exact byte-for-byte signature of the prior fabricated value
+        # (des_bin + SYSTEM_PATH_FALLBACK only) and rewrite from the live
+        # install-time PATH. Probability of a user manually configuring
+        # exactly this value is effectively zero, so this is safe to assume
+        # is installer-fabricated.
+        legacy_fabricated_path = f"{des_bin_path}:{self.SYSTEM_PATH_FALLBACK}"
+        if existing_path == legacy_fabricated_path:
+            live_path = os.environ.get("PATH") or self.SYSTEM_PATH_FALLBACK
+            config["env"]["PATH"] = des_bin_path + ":" + live_path
+            if not context.dry_run:
+                self._save_settings(settings_file, config, context)
+            return
+
         if des_bin_path in existing_path.split(":"):
             if existing_path != config["env"].get("PATH", ""):
                 config["env"]["PATH"] = existing_path
@@ -917,7 +948,11 @@ class DESPlugin(InstallationPlugin):
         if existing_path:
             config["env"]["PATH"] = des_bin_path + ":" + existing_path
         else:
-            config["env"]["PATH"] = des_bin_path + ":" + self.SYSTEM_PATH_FALLBACK
+            # Seed from the user's live install-time PATH so binaries reachable
+            # from their shell (claude itself in ~/.local/bin, pnpm, node, etc.)
+            # remain reachable inside Claude Code sessions and hooks.
+            live_path = os.environ.get("PATH") or self.SYSTEM_PATH_FALLBACK
+            config["env"]["PATH"] = des_bin_path + ":" + live_path
 
         if not context.dry_run:
             self._save_settings(settings_file, config, context)

--- a/tests/installer/unit/plugins/test_des_shim_installation.py
+++ b/tests/installer/unit/plugins/test_des_shim_installation.py
@@ -7,12 +7,15 @@ Tests verify that _install_des_shims() correctly:
 4. Is idempotent: repeated calls do not duplicate PATH or error
 5. validate_prerequisites fails when a shim source file is missing
 6. PATH is prepended even when an existing entry is a prefix of DES_BIN_PATH
-7. System paths (/usr/bin etc.) are included when settings.json starts empty
+7. The live install-time os.environ["PATH"] is preserved when settings.json
+   starts empty (so user-visible binaries in ~/.local/bin etc. remain reachable)
 8. env.PATH contains no $HOME literal (runtime resolvability guard)
 9. Shims are resolvable via shutil.which using the installed PATH value
 10. Pre-existing $HOME entries are normalized to absolute paths on prepend
+11. Settings written by older installer versions (the broken
+    '<des_bin>:<SYSTEM_PATH_FALLBACK>' signature) are auto-healed on re-install
 
-Test budget: 10 behaviors x 2 = 20 max tests. Using 10 (one per behavior).
+Test budget: 11 behaviors x 2 = 22 max tests. Using 11 (one per behavior).
 """
 
 import json
@@ -20,6 +23,8 @@ import shutil
 import stat
 from pathlib import Path
 from unittest.mock import MagicMock
+
+import pytest
 
 from scripts.install.plugins.base import InstallContext
 from scripts.install.plugins.des_plugin import DESPlugin
@@ -257,31 +262,72 @@ class TestInstallIsIdempotentForPathAndShims:
             )
 
 
-class TestSystemPathsIncludedWhenSettingsStartsEmpty:
-    """System directories must be reachable after install on a fresh machine.
+class TestLivePathPreservedWhenSettingsStartsEmpty:
+    """The user's live install-time PATH must be preserved on a fresh install.
 
     Behavior #7: when settings.json has no prior env.PATH, the installer must
-    write a complete PATH that includes POSIX system directories — not only
-    $HOME/.claude/bin — because Claude Code env entries REPLACE the shell PATH
-    rather than prepending to it.
+    seed env.PATH from os.environ["PATH"] (the live install-time PATH the user
+    invoked nwave-ai with), prepended with $HOME/.claude/bin. Claude Code
+    REPLACES env.PATH (no merge with the inherited shell PATH), so seeding
+    from a hardcoded minimum would strip user-visible directories such as
+    ~/.local/bin (where pipx-installed CLIs including claude/nwave-ai live),
+    ~/.deno/bin, /snap/bin, etc.
     """
 
-    def test_system_paths_present_when_settings_json_starts_empty(
-        self, tmp_path: Path
+    def test_live_install_time_path_preserved_when_settings_json_starts_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """
         GIVEN: settings.json does not exist (fresh install, no prior env.PATH)
+          AND: os.environ["PATH"] contains user-visible dirs (~/.local/bin,
+               ~/.deno/bin, /snap/bin) alongside system dirs
         WHEN: _install_des_shims() is called
-        THEN: the resulting env.PATH contains /usr/local/bin, /usr/bin, /bin,
-              /usr/sbin, /sbin as colon-delimited segments so that system tools
-              remain reachable after install
-        AND: $HOME/.claude/bin is still the first segment (DES tools take priority)
+        THEN: settings.json env.PATH equals
+              "<des_bin>:<os.environ['PATH']>" verbatim — the live install-time
+              PATH is preserved so binaries the user's shell can find remain
+              reachable inside Claude Code sessions and hooks.
         """
         context, _shims_dir, claude_dir = _make_context(tmp_path)
-        # _make_context creates claude_dir but no settings.json — fresh install
         assert not (claude_dir / "settings.json").exists(), (
             "Pre-condition failed: settings.json must not exist before install"
         )
+
+        # Simulate a typical user PATH containing dirs that the legacy
+        # SYSTEM_PATH_FALLBACK constant would have stripped.
+        live_path = (
+            "/home/u/.local/bin:/home/u/.deno/bin:/home/u/bin:"
+            "/usr/local/bin:/usr/bin:/bin:/snap/bin"
+        )
+        monkeypatch.setenv("PATH", live_path)
+
+        plugin = DESPlugin()
+        plugin._install_des_shims(context)
+
+        settings_file = claude_dir / "settings.json"
+        config = json.loads(settings_file.read_text(encoding="utf-8"))
+        path_value = config.get("env", {}).get("PATH", "")
+
+        des_bin = str(claude_dir / "bin")
+        expected = f"{des_bin}:{live_path}"
+        assert path_value == expected, (
+            f"Expected env.PATH={expected!r}, got {path_value!r}. "
+            "On a fresh install the user's live install-time PATH must be "
+            "preserved verbatim and prefixed with the DES bin dir."
+        )
+
+    def test_falls_back_to_system_paths_when_env_path_is_unset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        GIVEN: settings.json does not exist AND os.environ has no PATH at all
+        WHEN: _install_des_shims() is called
+        THEN: env.PATH falls back to "<des_bin>:<SYSTEM_PATH_FALLBACK>" so
+              that system tools (python3, grep, git) remain reachable. The
+              hardcoded fallback is a last resort — it is only used when the
+              installer cannot read a live PATH from the environment.
+        """
+        context, _shims_dir, claude_dir = _make_context(tmp_path)
+        monkeypatch.delenv("PATH", raising=False)
 
         plugin = DESPlugin()
         plugin._install_des_shims(context)
@@ -291,26 +337,15 @@ class TestSystemPathsIncludedWhenSettingsStartsEmpty:
         path_value = config.get("env", {}).get("PATH", "")
         path_segments = path_value.split(":")
 
-        required_system_paths = [
-            "/usr/local/bin",
-            "/usr/bin",
-            "/bin",
-            "/usr/sbin",
-            "/sbin",
-        ]
-        for system_path in required_system_paths:
-            assert system_path in path_segments, (
-                f"System path '{system_path}' missing from env.PATH after install "
-                f"on empty settings. PATH={path_value!r}. "
-                "Claude Code replaces PATH; omitting system dirs breaks all bare "
-                "command lookups (python3, grep, git, etc.)."
-            )
-
-        expected_des_bin = str(claude_dir / "bin")
-        assert path_segments[0] == expected_des_bin, (
-            f"DES bin dir must be the first PATH segment. "
-            f"Expected: {expected_des_bin!r}, got: {path_segments[0]!r}"
+        des_bin = str(claude_dir / "bin")
+        assert path_segments[0] == des_bin, (
+            f"DES bin dir must be first PATH segment. Got: {path_segments[0]!r}"
         )
+        for system_path in ["/usr/local/bin", "/usr/bin", "/bin"]:
+            assert system_path in path_segments, (
+                f"Fallback system path '{system_path}' missing from "
+                f"env.PATH={path_value!r} when os.environ has no PATH."
+            )
 
 
 class TestEnvPathContainsNoDollarHomeLiteral:
@@ -423,4 +458,60 @@ class TestExistingDollarHomeEntriesNormalizedOnPrepend:
         assert segments[0] == expected_des_bin, (
             f"DES bin path must be first segment. "
             f"Expected: {expected_des_bin!r}, got: {segments[0]!r}"
+        )
+
+
+class TestLegacyFabricatedPathAutoHealedOnReinstall:
+    """Settings written by older installer versions must be auto-healed.
+
+    Behavior #11: Older installer versions seeded env.PATH from a hardcoded
+    minimum (SYSTEM_PATH_FALLBACK) on fresh installs, producing the exact
+    value '<des_bin>:<SYSTEM_PATH_FALLBACK>'. That value stripped the user's
+    real PATH (~/.local/bin etc.) and broke bare-name resolution of binaries
+    like claude/nwave-ai. The idempotency guard would otherwise see
+    ~/.claude/bin already present and short-circuit, leaving affected users
+    stuck. This test asserts that re-running install rewrites the legacy
+    signature using the live os.environ["PATH"].
+    """
+
+    def test_legacy_fabricated_path_replaced_with_live_environment(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        GIVEN: settings.json env.PATH equals the legacy installer-fabricated
+               value '<absolute_des_bin>:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin'
+          AND: os.environ["PATH"] contains the user's real shell PATH
+               including ~/.local/bin (which the legacy value stripped)
+        WHEN: _install_des_shims() is called
+        THEN: env.PATH is rewritten to "<des_bin>:<os.environ['PATH']>",
+              restoring access to the user's real PATH dirs.
+        """
+        context, _shims_dir, claude_dir = _make_context(tmp_path)
+        des_bin = str(claude_dir / "bin")
+
+        # Pre-seed settings.json with the exact legacy signature.
+        legacy_value = f"{des_bin}:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        settings_file = claude_dir / "settings.json"
+        settings_file.write_text(
+            json.dumps({"env": {"PATH": legacy_value}}), encoding="utf-8"
+        )
+
+        # Simulate the user's real shell PATH at install time.
+        live_path = (
+            "/home/u/.local/bin:/home/u/.deno/bin:"
+            "/usr/local/bin:/usr/bin:/bin:/snap/bin"
+        )
+        monkeypatch.setenv("PATH", live_path)
+
+        plugin = DESPlugin()
+        plugin._install_des_shims(context)
+
+        config = json.loads(settings_file.read_text(encoding="utf-8"))
+        path_value = config.get("env", {}).get("PATH", "")
+
+        expected = f"{des_bin}:{live_path}"
+        assert path_value == expected, (
+            f"Auto-heal failed. Expected env.PATH={expected!r}, got "
+            f"{path_value!r}. Legacy installer-fabricated PATH value should be "
+            "rewritten from os.environ['PATH'] on re-install."
         )


### PR DESCRIPTION
## Summary

Fixes #48.

When `nwave-ai install` runs against a Claude Code config that has no pre-existing `env.PATH` in `~/.claude/settings.json`, the installer used to write a brand-new `env.PATH` value composed of `~/.claude/bin` plus a hardcoded minimal POSIX list (`/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`).

Because Claude Code **replaces** `env.PATH` (rather than merging with the inherited shell PATH — see the function's own docstring), this stripped every user-visible directory the user's login shell normally has on PATH: `~/.local/bin` (where `pipx`-installed CLIs including `claude` and `nwave-ai` itself live), `~/.deno/bin`, `~/.cargo/bin`, `/snap/bin`, `~/bin`, etc.

After install, Claude Code emitted a yellow PATH warning at startup, and bare-name resolution failed inside the session for binaries that the user's shell could find. Re-running `nwave-ai install` did not self-heal because the idempotency guard saw `~/.claude/bin` already in PATH and short-circuited.

## Fix

Two changes in `scripts/install/plugins/des_plugin.py::_update_path_in_settings`:

1. **Seed from the live install-time PATH** — when `settings.json` has no prior `env.PATH`, read `os.environ["PATH"]` and prepend `~/.claude/bin`. The hardcoded `SYSTEM_PATH_FALLBACK` is now a true last-resort fallback used only when `os.environ` has no `PATH` set (highly unusual).

2. **Auto-heal legacy fabricated values** — detect the exact byte-for-byte signature of the prior installer-fabricated `<des_bin>:<SYSTEM_PATH_FALLBACK>` value and rewrite it from the live `os.environ["PATH"]`. This means existing affected users get fixed on their next `nwave-ai install` without any manual intervention. The probability of a user manually configuring exactly this value is effectively zero, so this is safe to assume installer-fabricated.

The `~/.claude/bin` prepend (motivated by #36 — bare-name `des-log-phase` resolution) is unchanged.

## Tests

In `tests/installer/unit/plugins/test_des_shim_installation.py`:

- **Removed** `TestSystemPathsIncludedWhenSettingsStartsEmpty`, which pinned the buggy behavior as a required contract.
- **Added** `TestLivePathPreservedWhenSettingsStartsEmpty` with two cases:
  - `test_live_install_time_path_preserved_when_settings_json_starts_empty` — asserts `env.PATH` equals `<des_bin>:<os.environ['PATH']>` verbatim when env is set.
  - `test_falls_back_to_system_paths_when_env_path_is_unset` — asserts `SYSTEM_PATH_FALLBACK` is used when `os.environ` has no `PATH`.
- **Added** `TestLegacyFabricatedPathAutoHealedOnReinstall::test_legacy_fabricated_path_replaced_with_live_environment` — regression test for the auto-heal behavior.

Test budget bumped to 11 behaviors (was 10).

## Test plan

- [x] `pytest tests/installer/unit/plugins/test_des_shim_installation.py` — 12 passed
- [x] `pytest tests/installer/unit/plugins/ tests/bugs/` — 149 passed (4 skipped, 2 xfail; all unrelated)
- [x] `pytest tests/nwave_ai/doctor/` — 52 passed (PATH parser unaffected)
- [x] `ruff format` + `ruff check` on changed files — clean
- [ ] CI on this PR

## Notes for reviewers

- I committed with `PRE_COMMIT_ALLOW_NO_CONFIG=1` because `.pre-commit-config.yaml` is not present in the public repo (CONTRIBUTING.md mentions it but it's evidently maintained only in the private dev tree). Not a `--no-verify` bypass — the hook itself suggested this env var.
- One pre-existing collection error in `tests/installer/unit/validation/test_measure_doc_tokens.py` (missing `tiktoken` dep) — orthogonal to this change; not addressed here.

🤖 Drafted with the help of Claude Code, reviewed by @martinov before posting.