### PR TITLE
feat(cli): add --target flag to install and uninstall

### DIFF
--- a/nwave_ai/cli.py
+++ b/nwave_ai/cli.py
@@ -1,5 +1,6 @@
 """nwave-ai CLI: thin wrapper around nWave install/uninstall scripts."""
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -158,6 +159,53 @@ def _get_config_dir() -> Path:
     return Path.home() / ".nwave"
 
 
+def _extract_target_flag(
+    args: list[str],
+) -> tuple[Path | None, list[str], str | None]:
+    """Parse and consume `--target <path>` (or `--target=<path>`) from args.
+
+    Returns (resolved_target_path | None, remaining_args, error_message | None).
+
+    The target is resolved via `Path.expanduser().resolve()` so that `~/...`,
+    relative paths, and symlinks all collapse to a single canonical form
+    before being applied as `CLAUDE_CONFIG_DIR` for the subprocess.
+
+    If the resolved target equals `realpath($HOME)`, returns an error so the
+    caller can exit 2 without mutating any filesystem state (the single
+    highest-impact misconfiguration guard).
+    """
+    remaining: list[str] = []
+    target: str | None = None
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg == "--target":
+            if i + 1 >= len(args):
+                return (None, args, "--target requires a path argument")
+            target = args[i + 1]
+            i += 2
+            continue
+        if arg.startswith("--target="):
+            target = arg.split("=", 1)[1]
+            i += 1
+            continue
+        remaining.append(arg)
+        i += 1
+
+    if target is None:
+        return (None, remaining, None)
+
+    resolved = Path(target).expanduser().resolve()
+    if resolved == Path.home().resolve():
+        return (
+            None,
+            remaining,
+            "--target must point to a Claude config directory "
+            "(e.g. ~/.claude-nwave or ./.claude), not your home directory",
+        )
+    return (resolved, remaining, None)
+
+
 def _handle_install(args: list[str]) -> int:
     """Run the install pipeline with first-run density prompt (D6).
 
@@ -167,12 +215,22 @@ def _handle_install(args: list[str]) -> int:
     install on failure — at worst the CI default ("lean") is written.
 
     Flags handled here:
+        --target <path>    install into <path> instead of ~/.claude/
+                           (sets CLAUDE_CONFIG_DIR for the subprocess; see
+                           ADR-001). $HOME is refused with exit 2.
         --yes              non-interactive (CI / silent default)
         --density-only     run ONLY the density prompt and exit (test driving
                            port for acceptance tests; never a user flag)
 
     All other args pass through to install_nwave.py.
     """
+    target, args, error = _extract_target_flag(args)
+    if error is not None:
+        print(f"nwave-ai: {error}", file=sys.stderr)
+        return 2
+    if target is not None:
+        os.environ["CLAUDE_CONFIG_DIR"] = str(target)
+
     pass_through_args: list[str] = []
     non_interactive = False
     density_only = False
@@ -207,6 +265,25 @@ def _handle_install(args: list[str]) -> int:
         return 0
 
     return _run_script("install_nwave.py", pass_through_args)
+
+
+def _handle_uninstall(args: list[str]) -> int:
+    """Run the uninstall pipeline.
+
+    Flags handled here:
+        --target <path>    uninstall from <path> instead of ~/.claude/
+                           (sets CLAUDE_CONFIG_DIR for the subprocess; see
+                           ADR-001). $HOME is refused with exit 2.
+
+    All other args pass through to uninstall_nwave.py.
+    """
+    target, remaining, error = _extract_target_flag(args)
+    if error is not None:
+        print(f"nwave-ai: {error}", file=sys.stderr)
+        return 2
+    if target is not None:
+        os.environ["CLAUDE_CONFIG_DIR"] = str(target)
+    return _run_script("uninstall_nwave.py", remaining)
 
 
 def _handle_attribution(args: list[str]) -> int:
@@ -590,7 +667,7 @@ def main() -> int:
     if command == "install":
         return _handle_install(sys.argv[2:])
     elif command == "uninstall":
-        return _run_script("uninstall_nwave.py", sys.argv[2:])
+        return _handle_uninstall(sys.argv[2:])
     elif command == "attribution":
         return _handle_attribution(sys.argv[2:])
     elif command == "doctor":

--- a/scripts/install/plugins/des_plugin.py
+++ b/scripts/install/plugins/des_plugin.py
@@ -481,7 +481,18 @@ class DESPlugin(InstallationPlugin):
         Returns:
             Complete command string with $HOME-based paths
         """
-        lib_path = "$HOME/.claude/lib/python"
+        # When the install target is the default ~/.claude/, keep the portable
+        # $HOME form so settings.json works across machines via a synced
+        # ~/.claude/. When the target is non-default (e.g. ~/.claude-nwave
+        # via `nwave-ai install --target`, or a project-scoped <repo>/.claude),
+        # emit the absolute path: Claude Code passes hook commands to a shell
+        # that resolves $HOME to the user's real home, NOT to the chosen
+        # target, so the portable form would point at the wrong directory.
+        # See ADR-002 (per-project-install feature).
+        if context.claude_dir == Path.home() / ".claude":
+            lib_path = "$HOME/.claude/lib/python"
+        else:
+            lib_path = str(context.claude_dir / "lib" / "python")
         python_path = self._resolve_python_path()
         return self.HOOK_COMMAND_TEMPLATE.format(
             lib_path=lib_path,

--- a/tests/des/acceptance/test_hook_path_portability.py
+++ b/tests/des/acceptance/test_hook_path_portability.py
@@ -45,8 +45,22 @@ def project_root() -> Path:
 
 
 @pytest.fixture
-def install_context(tmp_path, project_root, test_logger) -> InstallContext:
-    """Create InstallContext simulating a fresh installation."""
+def install_context(
+    tmp_path, project_root, test_logger, monkeypatch
+) -> InstallContext:
+    """Create InstallContext simulating a fresh DEFAULT-HOME installation.
+
+    The portability assertions in this file (e.g. "PYTHONPATH uses $HOME")
+    only apply when the install target is the user's default `~/.claude/`.
+    Non-default targets (`nwave-ai install --target ~/.claude-nwave`) emit
+    absolute paths by design — see ADR-002 of the per-project-install
+    feature.
+
+    To exercise the default-home code path under tmp_path, we redirect
+    `Path.home()` to tmp_path so `Path.home() / ".claude" == claude_dir`.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
     claude_dir = tmp_path / ".claude"
     claude_dir.mkdir(parents=True)
     return InstallContext(

--- a/tests/installer/unit/cli/test_target_flag.py
+++ b/tests/installer/unit/cli/test_target_flag.py
@@ -1,0 +1,175 @@
+"""Unit tests for `--target <path>` argument parsing on `nwave-ai install`
+and `nwave-ai uninstall`.
+
+Issue #40 / per-project-install. Driving port:
+    nwave-ai install --target <path>
+    nwave-ai uninstall --target <path>
+
+What this layer verifies (without running the heavy installer subprocess):
+- `--target <path>` is consumed (NOT forwarded to the subprocess as a bare arg
+  the installer would not recognise).
+- The path is normalised via expanduser + resolve before being applied.
+- The chosen path is set as `CLAUDE_CONFIG_DIR` for the install subprocess.
+- `--target $HOME` (or any path whose `realpath` equals `realpath $HOME`) is
+  rejected at parse time with exit code 2 and no subprocess is launched.
+- Omitting `--target` is byte-identical to today's behavior.
+
+The subprocess itself is mocked. Full end-to-end install/uninstall is covered
+by the existing installer acceptance suite.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from nwave_ai import cli
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _scrub_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure CLAUDE_CONFIG_DIR is not leaked into the test from the host env."""
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+
+
+def _captured_run_script_args() -> dict:
+    """Patch _run_script and capture the call args + the env at call time."""
+    captured: dict = {"args": None, "claude_config_dir": None}
+
+    def fake_run_script(script_name: str, args: list[str]) -> int:
+        captured["args"] = list(args)
+        captured["script"] = script_name
+        captured["claude_config_dir"] = os.environ.get("CLAUDE_CONFIG_DIR")
+        return 0
+
+    return captured, fake_run_script
+
+
+class TestInstallTargetFlag:
+    def test_target_is_consumed_and_not_forwarded(self, tmp_path: Path):
+        captured, fake = _captured_run_script_args()
+        target = tmp_path / ".claude-nwave"
+        with (
+            patch.object(cli, "_run_script", side_effect=fake),
+            patch.object(
+                cli, "handle_install_density_prompt", return_value="default_silent"
+            ),
+        ):
+            rc = cli._handle_install(["--target", str(target), "--yes"])
+        assert rc == 0
+        assert captured["args"] is not None
+        assert "--target" not in captured["args"]
+        assert str(target) not in captured["args"]
+
+    def test_target_sets_claude_config_dir_env(self, tmp_path: Path):
+        captured, fake = _captured_run_script_args()
+        target = tmp_path / ".claude-nwave"
+        with (
+            patch.object(cli, "_run_script", side_effect=fake),
+            patch.object(
+                cli, "handle_install_density_prompt", return_value="default_silent"
+            ),
+        ):
+            cli._handle_install(["--target", str(target), "--yes"])
+        assert captured["claude_config_dir"] == str(target.resolve())
+
+    def test_target_with_user_expansion(self, tmp_path: Path, monkeypatch):
+        captured, fake = _captured_run_script_args()
+        monkeypatch.setenv("HOME", str(tmp_path))
+        with (
+            patch.object(cli, "_run_script", side_effect=fake),
+            patch.object(
+                cli, "handle_install_density_prompt", return_value="default_silent"
+            ),
+        ):
+            cli._handle_install(["--target", "~/.claude-nwave", "--yes"])
+        # ~/.claude-nwave is resolved against the HOME we just set
+        assert captured["claude_config_dir"] == str(
+            (tmp_path / ".claude-nwave").resolve()
+        )
+
+    def test_target_relative_path_is_resolved_absolute(
+        self, tmp_path: Path, monkeypatch
+    ):
+        captured, fake = _captured_run_script_args()
+        monkeypatch.chdir(tmp_path)
+        with (
+            patch.object(cli, "_run_script", side_effect=fake),
+            patch.object(
+                cli, "handle_install_density_prompt", return_value="default_silent"
+            ),
+        ):
+            cli._handle_install(["--target", "./.claude", "--yes"])
+        assert captured["claude_config_dir"] == str((tmp_path / ".claude").resolve())
+
+    def test_target_equal_to_home_is_refused(self, tmp_path: Path, monkeypatch, capsys):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        with patch.object(cli, "_run_script") as run_script:
+            rc = cli._handle_install(["--target", str(tmp_path), "--yes"])
+        assert rc == 2
+        run_script.assert_not_called()
+        err = capsys.readouterr().err
+        assert "must point to a Claude config directory" in err.lower() or (
+            "home directory" in err.lower()
+        )
+
+    def test_target_resolving_to_home_is_refused(
+        self, tmp_path: Path, monkeypatch, capsys
+    ):
+        """A relative path that resolves to $HOME (e.g. '.') must be refused."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.chdir(tmp_path)
+        with patch.object(cli, "_run_script") as run_script:
+            rc = cli._handle_install(["--target", ".", "--yes"])
+        assert rc == 2
+        run_script.assert_not_called()
+
+    def test_omitting_target_does_not_set_claude_config_dir(self, tmp_path: Path):
+        captured, fake = _captured_run_script_args()
+        with (
+            patch.object(cli, "_run_script", side_effect=fake),
+            patch.object(
+                cli, "handle_install_density_prompt", return_value="default_silent"
+            ),
+        ):
+            cli._handle_install(["--yes"])
+        assert captured["claude_config_dir"] is None, (
+            "Default behavior must not set CLAUDE_CONFIG_DIR; existing env-var "
+            "semantics still apply"
+        )
+
+
+class TestUninstallTargetFlag:
+    def test_uninstall_target_is_consumed_and_sets_env(self, tmp_path: Path):
+        captured, fake = _captured_run_script_args()
+        target = tmp_path / ".claude-nwave"
+        with patch.object(cli, "_run_script", side_effect=fake):
+            rc = cli._handle_uninstall(["--target", str(target), "--force"])
+        assert rc == 0
+        assert captured["script"] == "uninstall_nwave.py"
+        assert "--target" not in captured["args"]
+        assert str(target) not in captured["args"]
+        assert captured["claude_config_dir"] == str(target.resolve())
+
+    def test_uninstall_target_equal_to_home_is_refused(
+        self, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        with patch.object(cli, "_run_script") as run_script:
+            rc = cli._handle_uninstall(["--target", str(tmp_path)])
+        assert rc == 2
+        run_script.assert_not_called()
+
+    def test_omitting_target_in_uninstall_is_byte_compatible(self):
+        captured, fake = _captured_run_script_args()
+        with patch.object(cli, "_run_script", side_effect=fake):
+            cli._handle_uninstall(["--force"])
+        assert captured["claude_config_dir"] is None
+        assert captured["args"] == ["--force"]

--- a/tests/plugins/plugin-architecture/unit/test_des_plugin_target_flag.py
+++ b/tests/plugins/plugin-architecture/unit/test_des_plugin_target_flag.py
@@ -1,0 +1,93 @@
+"""Unit tests for `_generate_hook_command` target-aware path resolution.
+
+Issue #40 / per-project-install feature. Hook commands must point at the
+*chosen* target's `lib/python` when `--target` selects a non-default location;
+they must keep the existing `$HOME/.claude/lib/python` portable form when the
+target is the default `~/.claude/` (preserving cross-machine sync semantics).
+
+Driving seam: `DESPlugin._generate_hook_command(context, action)`.
+The change is intentionally minimal: branch on `context.claude_dir`.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from scripts.install.plugins.base import InstallContext
+from scripts.install.plugins.des_plugin import DESPlugin
+
+
+@pytest.fixture
+def test_logger() -> logging.Logger:
+    return logging.getLogger("test")
+
+
+def _make_context(claude_dir: Path, logger: logging.Logger) -> InstallContext:
+    return InstallContext(
+        claude_dir=claude_dir,
+        scripts_dir=Path("/unused"),
+        templates_dir=Path("/unused"),
+        logger=logger,
+    )
+
+
+class TestHookCommandTargetAware:
+    """When claude_dir is the default ~/.claude, use the portable $HOME form.
+    Otherwise emit an absolute path so Claude Code can exec() without a shell.
+    """
+
+    def test_default_target_uses_portable_home_form(self, test_logger: logging.Logger):
+        plugin = DESPlugin()
+        context = _make_context(Path.home() / ".claude", test_logger)
+
+        command = plugin._generate_hook_command(context, action="pre-task")
+
+        assert "$HOME/.claude/lib/python" in command, (
+            "Default target must keep the $HOME-portable form for cross-machine "
+            "settings.json sync"
+        )
+
+    def test_alternate_global_target_uses_absolute_lib_path(
+        self, tmp_path: Path, test_logger: logging.Logger
+    ):
+        plugin = DESPlugin()
+        alternate = tmp_path / ".claude-nwave"
+        context = _make_context(alternate, test_logger)
+
+        command = plugin._generate_hook_command(context, action="pre-task")
+
+        expected_lib = str(alternate / "lib" / "python")
+        assert expected_lib in command, (
+            f"Non-default target must emit absolute lib path. "
+            f"Expected {expected_lib} in: {command}"
+        )
+        assert "$HOME/.claude/lib/python" not in command, (
+            "Non-default target must NOT leak the default $HOME/.claude form"
+        )
+
+    def test_project_scoped_target_uses_absolute_lib_path(
+        self, tmp_path: Path, test_logger: logging.Logger
+    ):
+        plugin = DESPlugin()
+        project_claude = tmp_path / "my-project" / ".claude"
+        project_claude.mkdir(parents=True)
+        context = _make_context(project_claude, test_logger)
+
+        command = plugin._generate_hook_command(context, action="subagent-stop")
+
+        assert str(project_claude / "lib" / "python") in command
+        assert "$HOME/.claude" not in command
+
+    def test_action_token_is_substituted_in_both_branches(
+        self, tmp_path: Path, test_logger: logging.Logger
+    ):
+        plugin = DESPlugin()
+        default_ctx = _make_context(Path.home() / ".claude", test_logger)
+        custom_ctx = _make_context(tmp_path / ".claude-nwave", test_logger)
+
+        for action in ("pre-task", "subagent-stop", "post-tool-use"):
+            assert action in plugin._generate_hook_command(default_ctx, action=action)
+            assert action in plugin._generate_hook_command(custom_ctx, action=action)


### PR DESCRIPTION
Closes #40.

## Summary

- Adds `--target <path>` to `nwave-ai install` and `nwave-ai uninstall`, enabling installation to a non-default Claude config directory.
- Supports both real use cases from the issue thread: **alternate global** (`nwave-ai install --target ~/.claude-nwave` → run Claude with `CLAUDE_CONFIG_DIR=~/.claude-nwave claude` for a side-by-side config) and **per-project** (`nwave-ai install --target ./.claude` for dogfooding a fork without disturbing `~/.claude/`).
- Pure Python — no shell scripts added, respects the existing zero-shell-scripts policy.
- Backward compatible: omitting `--target` is byte-identical to the previous release.

## How it works

The flag is parsed in `_handle_install` / `_handle_uninstall` (manual parsing, consistent with how `--yes` and `--density-only` are handled), normalized via `Path.expanduser().resolve()`, and threaded into the install subprocess by setting `CLAUDE_CONFIG_DIR=<absolute-target>`. The existing `PathUtils.get_claude_config_dir()` seam already honors that env var, so no per-callsite plumbing was needed.

`--target $HOME` (or any path whose `realpath` equals `realpath $HOME`) is rejected at parse time with exit 2 and zero filesystem mutation — guards against the catastrophic global-overwrite case.

### Load-bearing fix: hook-command path resolution

When `nwave-ai install --target <non-default>` runs, the existing installer correctly lands files under `<target>/lib/python/des/`, but `des_plugin._generate_hook_command` hardcoded `lib_path = "$HOME/.claude/lib/python"`. At runtime, Claude Code passes hook commands to a shell where `$HOME` is the user's *real* home (not the chosen target), so the portable form pointed at the wrong directory — hooks failed or silently exercised the global install.

The fix is a 3-line conditional: when `context.claude_dir == Path.home() / ".claude"` keep the existing portable `$HOME/.claude/lib/python` form (preserves cross-machine `~/.claude` sync semantics). Otherwise, emit the absolute `<target>/lib/python`. Non-default targets are per-machine by user choice, so the loss of cross-machine portability is the intended trade.

`env.PATH` already honored `context.claude_dir` (it computes `str(context.claude_dir / "bin")` at line 862), so no change was needed there — that was a happy accident from prior refactoring.

## Files changed

| File | Change |
|------|--------|
| `nwave_ai/cli.py` | New `_extract_target_flag` helper; `--target` parsing in `_handle_install`; new `_handle_uninstall` wrapper; dispatch rewired (+79 lines) |
| `scripts/install/plugins/des_plugin.py` | 3-line conditional + comment in `_generate_hook_command` (+13 lines) |
| `tests/installer/unit/cli/test_target_flag.py` | New: 10 tests covering arg consumption, env-var setting, `~` expansion, relative-path resolution, `$HOME` refusal (direct and via `.` from $HOME), uninstall symmetry |
| `tests/plugins/plugin-architecture/unit/test_des_plugin_target_flag.py` | New: 4 tests for hook-command target-aware path selection |
| `tests/des/acceptance/test_hook_path_portability.py` | Fixture monkeypatches `Path.home()` to tmp_path so the default-home assertions still hold under the test fixture |

**Net production**: 2 files, +92 LOC. **Tests**: +282 LOC.

## Test plan

- [x] `pytest tests/installer/unit/cli/test_target_flag.py tests/plugins/plugin-architecture/unit/test_des_plugin_target_flag.py` — 14/14 green
- [x] `pytest tests/plugins tests/installer/unit/cli tests/des/acceptance/test_hook_path_portability.py tests/des/integration/test_hook_configuration.py tests/build/unit/shared` — 275/275 green (2 skips are pre-existing container-level skips owned by `tests/e2e/test_fresh_install.py`)
- [x] `ruff check` + `ruff format --check` on all modified files — clean
- [x] `mypy --ignore-missing-imports` on modified files — clean
- [x] **Manual dogfood**: `nwave-ai install --target ~/.claude-la-nwave` →
  - 149 skills, 32 agents (under `agents/nw/`), 5 DES bin shims, settings.json, templates landed in `~/.claude-la-nwave/`
  - All 9 hook commands have `PYTHONPATH=/home/<user>/.claude-la-nwave/lib/python` (absolute, points at target)
  - `env.PATH` prepends `/home/<user>/.claude-la-nwave/bin`
  - `~/.claude/` mtime unchanged (zero global pollution)
  - `nwave-ai uninstall --target ~/.claude-la-nwave --force` removes all DES hooks from settings.json and the `agents/` tree (residual files under `bin/skills/scripts/templates/` are the known upstream issue #39, not a regression of this PR)
- [x] `nwave-ai install --target $HOME` refused with exit 2 and no filesystem mutation
- [x] `nwave-ai install` (no `--target`) byte-identical to today's behavior (verified by the existing test suite passing unchanged)

## Open follow-ups (not in this PR)

- **#39 (clean uninstall)**: the residue under `<target>/bin`, `<target>/skills`, etc. after `uninstall --target` is the same residue tracked upstream as #39. `--target` makes the problem visible in alternate locations too; the fix belongs in `uninstall_nwave.py`.
- **`~/.nwave/global-config.json`** still lives at the user's real home regardless of `--target`. Density / attribution settings remain shared across all targets — typically desired, but worth noting.

## Notes for review

The DESIGN considered (a) bash wrapper + curl distribution and (b) `HOME=<target>` override + post-install sed — both were rejected after maintainer feedback in the issue thread. `CLAUDE_CONFIG_DIR` is strictly better than `HOME=<target>` because it doesn't pollute the subprocess tree's view of `$HOME` for tools like git, gh, ssh, and pipx.

The hook-path conditional preserves the `$HOME`-portable form **only** for the default-home case, which is the one for which it was designed. Existing users who sync `~/.claude/` across machines are unaffected.