### PR TITLE
fix: promote jsonschema to base runtime dependency (issue #60)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,8 @@ dependencies = [
     "pyyaml>=6.0",
     "packaging>=21.0",
     "tomli>=2.0.0; python_version < '3.11'",
-    "typing_extensions>=4.0"
+    "typing_extensions>=4.0",
+    "jsonschema>=4.0.0"
 ]
 
 [project.optional-dependencies]
@@ -108,9 +109,7 @@ dev = [
     "tiktoken>=0.7.0",
     # E2E container testing
     "testcontainers>=4.0.0",
-    "docker>=7.0.0",
-    # JSON Schema validation (used by tests/outcomes + tests/feature_delta)
-    "jsonschema>=4.0.0"
+    "docker>=7.0.0"
 ]
 test = [
     "pytest>=8.0.0",
@@ -118,8 +117,7 @@ test = [
     "pytest-asyncio>=0.23.0",
     "pytest-xdist>=3.5.0",
     "pytest-bdd>=7.0.0",
-    "respx>=0.20.0",
-    "jsonschema>=4.0.0"
+    "respx>=0.20.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

Promote `jsonschema` from dev/test optional extras to a base runtime dependency.

## Problem

`nwave_ai/outcomes/application/registry_service.py:16` imports `jsonschema` at module level:

```python
from jsonschema import Draft7Validator
```

This import is reached unconditionally via `nwave_ai/outcomes/cli.py:25` → `nwave_ai/cli.py:607` (`main()`). However, `jsonschema>=4.0.0` was only declared under `[project.optional-dependencies]` for `dev` and `test` extras — never in the base `dependencies` list.

**Result**: `nwave-ai outcomes check-delta` crashes with `ModuleNotFoundError: No module named 'jsonschema'` on every standard install (`pip install nwave-ai` or `uv tool install nwave-ai`).

## Fix

- Add `jsonschema>=4.0.0` to base `[project] dependencies`
- Remove `jsonschema>=4.0.0` from `dev` and `test` optional extras (redundant once it's a base dependency)

## Verification

After install, `nwave-ai outcomes check-delta` no longer crashes on import.

Fixes #60