### PR TITLE
Fix Codex command-skill installation

### DIFF
--- a/scripts/install/plugins/codex_skills_plugin.py
+++ b/scripts/install/plugins/codex_skills_plugin.py
@@ -21,7 +21,7 @@ from scripts.install.plugins.base import (
     InstallContext,
     PluginResult,
 )
-from scripts.shared.agent_catalog import load_public_agents
+from scripts.shared.agent_catalog import detect_command_skills, load_public_agents
 from scripts.shared.platform_contracts import CODEX_SKILL_FORBIDDEN_FIELDS
 from scripts.shared.skill_distribution import (
     enumerate_skills,
@@ -231,8 +231,11 @@ class CodexSkillsPlugin(InstallationPlugin):
                 build_ownership_map(agents_dir) if agents_dir.exists() else {}
             )
 
+            command_skills = detect_command_skills(skills_source)
             entries = enumerate_skills(skills_source)
-            entries = filter_public_skills(entries, public_agents, ownership_map)
+            entries = filter_public_skills(
+                entries, public_agents, ownership_map, command_skills
+            )
 
             installed_names: list[str] = []
             installed_files: list[Path] = []

--- a/scripts/install/plugins/opencode_skills_plugin.py
+++ b/scripts/install/plugins/opencode_skills_plugin.py
@@ -24,7 +24,7 @@ from scripts.install.plugins.base import (
     InstallContext,
     PluginResult,
 )
-from scripts.shared.agent_catalog import load_public_agents
+from scripts.shared.agent_catalog import detect_command_skills, load_public_agents
 from scripts.shared.platform_contracts import OPENCODE_SKILL_FORBIDDEN_FIELDS
 from scripts.shared.skill_distribution import (
     SkillEntry,
@@ -263,8 +263,11 @@ class OpenCodeSkillsPlugin(InstallationPlugin):
                 build_ownership_map(agents_dir) if agents_dir.exists() else {}
             )
 
+            command_skills = detect_command_skills(skills_source)
             entries = enumerate_skills(skills_source)
-            entries = filter_public_skills(entries, public_agents, ownership_map)
+            entries = filter_public_skills(
+                entries, public_agents, ownership_map, command_skills
+            )
 
             duplicate_names = _detect_duplicate_names(entries)
 

--- a/tests/installer/unit/plugins/test_codex_skills_plugin.py
+++ b/tests/installer/unit/plugins/test_codex_skills_plugin.py
@@ -99,7 +99,7 @@ def _make_context(
         logger=MagicMock(),
         project_root=project_root,
         framework_source=framework_source,
-        dev_mode=True,  # bypass public-agent filtering
+        dev_mode=public_agents_yaml is None,  # bypass filtering only without catalog
     )
     return context, project_root, framework_source
 
@@ -320,6 +320,51 @@ class TestInstallCopiesSkills:
             (codex_skills_dir / ".nwave-manifest.json").read_text(encoding="utf-8")
         )
         assert manifest["installed_skills"] == ["nw-alpha", "nw-beta"]
+
+    def test_install_includes_command_skill_without_agent_owner(
+        self, tmp_path, monkeypatch
+    ):
+        """
+        GIVEN: Public-agent filtering is enabled
+            AND a command-skill has user-invocable frontmatter but no owning agent
+        WHEN: install() runs
+        THEN: The command-skill is installed while non-command orphan skills are excluded
+        """
+        skills = {
+            "nw-refactor": (
+                "---\n"
+                "name: nw-refactor\n"
+                "description: Refactor command\n"
+                "user-invocable: true\n"
+                "---\n"
+                "# Refactor\n"
+            ),
+            "nw-orphan-internal": (
+                "---\n"
+                "name: nw-orphan-internal\n"
+                "description: Internal\n"
+                "user-invocable: false\n"
+                "disable-model-invocation: true\n"
+                "---\n"
+                "# Internal\n"
+            ),
+        }
+        context, _, _ = _make_context(
+            tmp_path,
+            skills=skills,
+            public_agents_yaml="agents:\n  product-owner:\n    public: true\n",
+        )
+        codex_skills_dir = tmp_path / "home" / ".agents" / "skills"
+        codex_config_dir = tmp_path / "home" / ".codex"
+        codex_config_dir.mkdir(parents=True)
+        _patch_codex_dirs(monkeypatch, codex_skills_dir, codex_config_dir)
+
+        plugin = CodexSkillsPlugin()
+        result = plugin.install(context)
+
+        assert result.success is True
+        assert (codex_skills_dir / "nw-refactor" / "SKILL.md").is_file()
+        assert not (codex_skills_dir / "nw-orphan-internal").exists()
 
 
 class TestVerify:

--- a/tests/installer/unit/plugins/test_opencode_skills_plugin.py
+++ b/tests/installer/unit/plugins/test_opencode_skills_plugin.py
@@ -243,6 +243,54 @@ class TestInstallTransformsSkillToOpenCodeFormat:
             },
         )
 
+    def test_install_includes_command_skill_without_agent_owner(
+        self, tmp_path, monkeypatch
+    ):
+        """
+        GIVEN: Public-agent filtering is enabled
+            AND a flat command-skill has user-invocable frontmatter but no owning agent
+        WHEN: install() runs
+        THEN: The command-skill is installed while non-command orphan skills are excluded
+        """
+        context, skills_source, target = _make_context(tmp_path)
+        monkeypatch.setattr(
+            "scripts.install.plugins.opencode_skills_plugin._opencode_skills_dir",
+            lambda: target,
+        )
+        (context.project_root / "nWave" / "framework-catalog.yaml").write_text(
+            "agents:\n  product-owner:\n    public: true\n"
+        )
+
+        command_dir = skills_source / "nw-refactor"
+        command_dir.mkdir()
+        (command_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: nw-refactor\n"
+            "description: Refactor command\n"
+            "user-invocable: true\n"
+            "---\n"
+            "# Refactor\n"
+        )
+
+        internal_dir = skills_source / "nw-orphan-internal"
+        internal_dir.mkdir()
+        (internal_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: nw-orphan-internal\n"
+            "description: Internal\n"
+            "user-invocable: false\n"
+            "disable-model-invocation: true\n"
+            "---\n"
+            "# Internal\n"
+        )
+
+        plugin = OpenCodeSkillsPlugin()
+        result = plugin.install(context)
+
+        assert result.success is True
+        assert (target / "nw-refactor" / "SKILL.md").is_file()
+        assert not (target / "nw-orphan-internal").exists()
+
 
 class TestInstallPrefixesDuplicateSkillNames:
     """Test that install() prefixes colliding skill names with agent group."""


### PR DESCRIPTION
## Summary
- include user-invocable command-skills in Codex skill filtering
- mirror the same command-skill inclusion for OpenCode skill filtering
- add regression coverage proving orphan command-skills like nw-refactor install while non-command orphan skills stay filtered

## Verification
- PYTHONPATH=/Users/soren.mahon@m10s.io/src/nWave .venv/bin/python -m pytest tests/installer/unit/plugins/test_codex_skills_plugin.py tests/installer/unit/plugins/test_opencode_skills_plugin.py
- isolated source installer run confirmed /tmp/nwave-codex-test/.agents/skills/nw-refactor/SKILL.md is created

## Notes
- Latest main already contains nWave/skills/nw-refactor/SKILL.md; the bug was that Codex/OpenCode public filtering excluded command-skills without agent ownership.