### PR TITLE
Declare jsonschema runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,8 @@ dependencies = [
     "pyyaml>=6.0",
     "packaging>=21.0",
     "tomli>=2.0.0; python_version < '3.11'",
-    "typing_extensions>=4.0"
+    "typing_extensions>=4.0",
+    "jsonschema>=4.0.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Fixes nWave-ai/nWave#60.

`nwave_ai.outcomes.application.registry_service` imports `jsonschema` at module import time through the user-facing `nwave-ai outcomes ...` command path. `jsonschema` was declared only in the `dev` and `test` extras, so a normal install can crash with `ModuleNotFoundError` when running outcomes commands.

This promotes `jsonschema>=4.0.0` to the base project dependencies while leaving the existing extras untouched.