### PR TITLE
fix(outcomes): load registry schema as a package resource

### DIFF
--- a/docs/reference/outcomes-cli.md
+++ b/docs/reference/outcomes-cli.md
@@ -76,6 +76,7 @@ nwave-ai outcomes register --id OUT-ID --kind KIND \
 |------|----------------------------------------------------------------------|
 | 0    | Outcome registered successfully.                                     |
 | 2    | Duplicate `--id` (already in registry), or invalid Outcome (schema). |
+| 3    | The packaged JSON Schema could not be loaded — the installation is incomplete. Reinstall `nwave-ai`. |
 
 ### Output
 
@@ -263,7 +264,7 @@ nwave-ai outcomes check-delta docs/feature/my-feature/feature-delta.md
 
 ## Registry schema
 
-The registry file is YAML matching the JSON Schema at `docs/product/outcomes/schema.json` (draft-07). Each entry is one element of the top-level `outcomes:` list.
+The registry file is YAML matching the JSON Schema shipped inside the package at `nwave_ai/outcomes/schema.json` (draft-07). Each entry is one element of the top-level `outcomes:` list.
 
 ### Top-level structure
 
@@ -346,5 +347,5 @@ Threshold: ≥ 0.4 → Tier-2 fires.
 - **[Your First Outcome](../guides/outcomes-first-outcome/README.md)** — tutorial for new authors.
 - **[How to resolve a collision](../guides/howto-resolve-outcomes-collision.md)** — triage flagged candidates.
 - **[Why an outcomes registry?](../product/outcomes/README.md)** — design rationale and locked decisions.
-- **JSON Schema** — `docs/product/outcomes/schema.json`.
+- **JSON Schema** — `nwave_ai/outcomes/schema.json`, loaded as a package resource so it travels with the install.
 - **Seeded registry** — `docs/product/outcomes/registry.yaml`.

--- a/docs/reference/outcomes-cli.md
+++ b/docs/reference/outcomes-cli.md
@@ -28,6 +28,8 @@ nwave-ai outcomes [--registry PATH] check-delta DELTA_PATH
 
 If the registry path does not exist, `register` and `check` create an empty skeleton (`schema_version: "0.1"`, `outcomes: []`) before proceeding. `check-delta` does the same.
 
+If the path cannot be read or created — a read-only filesystem, a denied permission, or a path occupied by a directory — every subcommand exits **4** and prints `ERROR: <cause>` naming the path on stderr.
+
 ## Verdict matrix
 
 The detector runs two tiers and combines them into a verdict.
@@ -77,6 +79,7 @@ nwave-ai outcomes register --id OUT-ID --kind KIND \
 | 0    | Outcome registered successfully.                                     |
 | 2    | Duplicate `--id` (already in registry), or invalid Outcome (schema). |
 | 3    | The packaged JSON Schema could not be loaded — the installation is incomplete. Reinstall `nwave-ai`. |
+| 4    | The registry path is unusable (read-only filesystem, permission denied, or not a regular file). |
 
 ### Output
 
@@ -135,6 +138,7 @@ nwave-ai outcomes check --input-shape SHAPE --output-shape SHAPE \
 |------|------------------------------------|
 | 0    | No collisions detected (`clean`).  |
 | 1    | One or more collisions detected.   |
+| 4    | The registry path is unusable.     |
 
 ### Output
 
@@ -221,6 +225,7 @@ nwave-ai outcomes check-delta DELTA_PATH
 | 0    | Zero collisions across all referenced OUT-ids.             |
 | 1    | One or more referenced OUT-ids collide with another entry. |
 | 2    | `delta_path` does not exist.                               |
+| 4    | The registry path is unusable.                             |
 
 ### Output
 

--- a/nwave_ai/outcomes/application/registry_service.py
+++ b/nwave_ai/outcomes/application/registry_service.py
@@ -2,16 +2,21 @@
 and JSON Schema validation.
 
 Driving port: register / load. Drives the RegistryReader and
-RegistryWriter driven ports. Validates every outcome against
-docs/product/outcomes/schema.json before persistence (fail-fast on
-malformed entries — protects the registry contract).
+RegistryWriter driven ports. Validates every outcome against the packaged
+schema resource ``nwave_ai/outcomes/schema.json`` before persistence
+(fail-fast on malformed entries — protects the registry contract).
+
+The schema is a package resource, not a repo-relative file: it must travel
+with the code into every install. Resolving it by walking out of the package
+lands in ``site-packages`` and breaks ``outcomes register`` for every user
+who installed the wheel.
 """
 
 from __future__ import annotations
 
 import json
 from functools import lru_cache
-from pathlib import Path
+from importlib import resources
 
 from jsonschema import Draft7Validator
 from jsonschema import ValidationError as JsonSchemaValidationError
@@ -24,13 +29,16 @@ from nwave_ai.outcomes.ports.registry_io import (  # noqa: TC001  # runtime DI
 )
 
 
-_SCHEMA_PATH = (
-    Path(__file__).resolve().parents[3]
-    / "docs"
-    / "product"
-    / "outcomes"
-    / "schema.json"
-)
+_SCHEMA_PACKAGE = "nwave_ai.outcomes"
+_SCHEMA_RESOURCE = "schema.json"
+
+
+class SchemaResourceUnavailableError(Exception):
+    """Raised when the packaged outcomes schema cannot be read or parsed.
+
+    Signals a broken installation (the resource is missing from the wheel or
+    unreadable), never a malformed outcome.
+    """
 
 
 class DuplicateOutcomeIdError(Exception):
@@ -51,7 +59,30 @@ class UnknownOutcomeIdError(Exception):
 
 @lru_cache(maxsize=1)
 def _load_validator() -> Draft7Validator:
-    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    """Return the validator built from the packaged schema resource.
+
+    Raises:
+        SchemaResourceUnavailableError: when the resource is missing,
+            unreadable, or not valid JSON.
+    """
+    try:
+        raw = (
+            resources.files(_SCHEMA_PACKAGE)
+            .joinpath(_SCHEMA_RESOURCE)
+            .read_text(encoding="utf-8")
+        )
+    except (FileNotFoundError, ModuleNotFoundError, OSError) as err:
+        raise SchemaResourceUnavailableError(
+            f"outcomes schema resource {_SCHEMA_PACKAGE}/{_SCHEMA_RESOURCE} "
+            f"is unreadable — the nwave-ai installation is incomplete: {err}"
+        ) from err
+    try:
+        schema = json.loads(raw)
+    except json.JSONDecodeError as err:
+        raise SchemaResourceUnavailableError(
+            f"outcomes schema resource {_SCHEMA_PACKAGE}/{_SCHEMA_RESOURCE} "
+            f"is not valid JSON: {err}"
+        ) from err
     return Draft7Validator(schema)
 
 

--- a/nwave_ai/outcomes/application/registry_service.py
+++ b/nwave_ai/outcomes/application/registry_service.py
@@ -71,7 +71,11 @@ def _load_validator() -> Draft7Validator:
             .joinpath(_SCHEMA_RESOURCE)
             .read_text(encoding="utf-8")
         )
-    except (FileNotFoundError, ModuleNotFoundError, OSError) as err:
+    # UnicodeDecodeError derives from ValueError, not OSError, so a resource
+    # that exists but is not valid UTF-8 would escape an OSError-only clause and
+    # reach the user as a raw traceback. FileNotFoundError is a subclass of
+    # OSError and is listed only for the reader's benefit.
+    except (OSError, UnicodeDecodeError) as err:
         raise SchemaResourceUnavailableError(
             f"outcomes schema resource {_SCHEMA_PACKAGE}/{_SCHEMA_RESOURCE} "
             f"is unreadable — the nwave-ai installation is incomplete: {err}"

--- a/nwave_ai/outcomes/cli.py
+++ b/nwave_ai/outcomes/cli.py
@@ -5,7 +5,8 @@ service calls (RegistryService.register, CollisionDetector.check,
 RegistryService.collision_check_for_id) and maps results to exit codes
 per feature-delta DESIGN:
 
-    register:    0 success, 2 duplicate id
+    register:    0 success, 2 duplicate id or invalid outcome,
+                 3 packaged schema resource unavailable
     check:       0 no collisions, 1 collision detected
     check-delta: 0 zero collisions across delta, 1 if any collision
 """
@@ -26,6 +27,7 @@ from nwave_ai.outcomes.application.registry_service import (
     DuplicateOutcomeIdError,
     InvalidOutcomeError,
     RegistryService,
+    SchemaResourceUnavailableError,
     UnknownOutcomeIdError,
 )
 from nwave_ai.outcomes.domain.outcome import InputShape, Outcome, OutputShape
@@ -102,6 +104,14 @@ def _run_register(args: argparse.Namespace, registry_path: Path) -> int:
     outcome = _build_outcome_from_args(args)
     try:
         service.register(outcome)
+    except SchemaResourceUnavailableError as err:
+        print(f"ERROR: {err}", file=sys.stderr)
+        print(
+            "Reinstall nwave-ai (e.g. `uv tool install --force nwave-ai`) "
+            "to restore the packaged outcomes schema.",
+            file=sys.stderr,
+        )
+        return 3
     except (DuplicateOutcomeIdError, InvalidOutcomeError) as err:
         print(f"ERROR: {err}", file=sys.stderr)
         return 2

--- a/nwave_ai/outcomes/cli.py
+++ b/nwave_ai/outcomes/cli.py
@@ -9,6 +9,9 @@ per feature-delta DESIGN:
                  3 packaged schema resource unavailable
     check:       0 no collisions, 1 collision detected
     check-delta: 0 zero collisions across delta, 1 if any collision
+
+    all:         4 the registry path is unusable (read-only filesystem,
+                 permission denied, or the path is not a regular file)
 """
 
 from __future__ import annotations
@@ -17,6 +20,7 @@ import argparse
 import re
 import sys
 from pathlib import Path
+from typing import get_args
 
 from nwave_ai.outcomes.adapters.yaml_registry import YamlRegistryAdapter
 from nwave_ai.outcomes.application.collision_detector import (
@@ -30,10 +34,29 @@ from nwave_ai.outcomes.application.registry_service import (
     SchemaResourceUnavailableError,
     UnknownOutcomeIdError,
 )
-from nwave_ai.outcomes.domain.outcome import InputShape, Outcome, OutputShape
+from nwave_ai.outcomes.domain.outcome import (
+    InputShape,
+    Outcome,
+    OutcomeKind,
+    OutputShape,
+)
 
 
 _OUT_ID_PATTERN = re.compile(r"\bOUT-[A-Z0-9-]+\b")
+
+# Derived, not restated: `OutcomeKind` in the domain is the single definition of
+# the kind vocabulary. The JSON Schema enum cannot be derived at runtime (it is
+# static data shipped in the wheel), so it is pinned to this same tuple by
+# tests/outcomes/unit/test_schema_validation.py instead.
+_KIND_CHOICES = get_args(OutcomeKind)
+
+
+class RegistryPathUnusableError(Exception):
+    """Raised when the registry path cannot be read or created.
+
+    Signals an environment problem (read-only filesystem, permission denied,
+    a path occupied by a directory), never a malformed outcome.
+    """
 
 
 _DEFAULT_REGISTRY = Path("docs") / "product" / "outcomes" / "registry.yaml"
@@ -55,7 +78,7 @@ def handle_outcomes(argv: list[str]) -> int:
     reg.add_argument(
         "--kind",
         required=True,
-        choices=["specification", "operation", "invariant"],
+        choices=_KIND_CHOICES,
     )
     reg.add_argument("--input-shape", required=True)
     reg.add_argument("--output-shape", required=True)
@@ -76,7 +99,11 @@ def handle_outcomes(argv: list[str]) -> int:
     chd.add_argument("delta_path", type=Path)
 
     args = parser.parse_args(argv)
-    registry_path = _ensure_registry(args.registry)
+    try:
+        registry_path = _ensure_registry(args.registry)
+    except RegistryPathUnusableError as err:
+        print(f"ERROR: {err}", file=sys.stderr)
+        return 4
 
     if args.cmd == "register":
         return _run_register(args, registry_path)
@@ -88,13 +115,29 @@ def handle_outcomes(argv: list[str]) -> int:
 
 
 def _ensure_registry(registry_path: Path) -> Path:
-    """Create an empty registry skeleton if missing, then return the path."""
-    if not registry_path.exists():
+    """Create an empty registry skeleton if missing, then return the path.
+
+    Raises:
+        RegistryPathUnusableError: when the path exists but is not a regular
+            file, or when the directory or skeleton file cannot be created
+            (read-only filesystem, permission denied, a parent that is a file).
+    """
+    if registry_path.exists():
+        if not registry_path.is_file():
+            raise RegistryPathUnusableError(
+                f"registry path {registry_path} exists but is not a regular file"
+            )
+        return registry_path
+    try:
         registry_path.parent.mkdir(parents=True, exist_ok=True)
         registry_path.write_text(
             'schema_version: "0.1"\noutcomes: []\n',
             encoding="utf-8",
         )
+    except OSError as err:
+        raise RegistryPathUnusableError(
+            f"cannot create registry at {registry_path}: {err}"
+        ) from err
     return registry_path
 
 

--- a/nwave_ai/outcomes/schema.json
+++ b/nwave_ai/outcomes/schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://nwave.ai/schemas/outcomes/outcome.json",
+  "title": "Outcome registry entry",
+  "description": "One registered outcome — a shipped capability identified by an OUT-id. Canonical key order: id, kind, summary, feature, inputs, output, keywords, artifact, related, superseded_by.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "kind",
+    "summary",
+    "feature",
+    "inputs",
+    "output",
+    "keywords",
+    "artifact",
+    "related",
+    "superseded_by"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^OUT-[A-Z0-9-]+$",
+      "description": "Registry-unique outcome identifier."
+    },
+    "kind": {
+      "type": "string",
+      "enum": ["specification", "operation", "invariant"],
+      "description": "Outcome category."
+    },
+    "summary": {
+      "type": "string",
+      "description": "One-line human summary. May be empty."
+    },
+    "feature": {
+      "type": "string",
+      "description": "Feature slug the outcome belongs to."
+    },
+    "inputs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["shape"],
+        "properties": {
+          "shape": {
+            "type": "string",
+            "description": "Canonical type expression of one input."
+          }
+        }
+      },
+      "description": "At least one input shape."
+    },
+    "output": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["shape"],
+      "properties": {
+        "shape": {
+          "type": "string",
+          "description": "Canonical type expression of the output."
+        }
+      }
+    },
+    "keywords": {
+      "type": "array",
+      "maxItems": 6,
+      "items": {"type": "string"},
+      "description": "Up to six intent keywords used by Tier-2 collision scoring."
+    },
+    "artifact": {
+      "type": "string",
+      "description": "Repo-relative path of the implementing artifact. May be empty."
+    },
+    "related": {
+      "type": "array",
+      "items": {"type": "string", "pattern": "^OUT-[A-Z0-9-]+$"},
+      "description": "OUT-ids of related outcomes."
+    },
+    "superseded_by": {
+      "type": ["string", "null"],
+      "pattern": "^OUT-[A-Z0-9-]+$",
+      "description": "OUT-id that supersedes this outcome, or null."
+    }
+  }
+}

--- a/tests/outcomes/unit/test_cli_registry_path.py
+++ b/tests/outcomes/unit/test_cli_registry_path.py
@@ -1,0 +1,90 @@
+"""Unit test: the CLI explains an unusable registry path instead of tracebacking.
+
+``_ensure_registry`` creates the registry skeleton on first use. That write was
+unguarded, and the package-resource fix (issue #63) is what makes ``register``
+reachable in an installed environment — so a read-only filesystem, a denied
+permission, or a path occupied by a directory is now the next failure a real
+user meets.
+
+WHEN the registry path cannot be read or created, the system SHALL print a
+message naming the path and the cause, and SHALL exit non-zero rather than
+raise.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nwave_ai.outcomes.cli import (
+    RegistryPathUnusableError,
+    _ensure_registry,
+    handle_outcomes,
+)
+
+
+_REGISTER_ARGV = [
+    "register",
+    "--id",
+    "OUT-1",
+    "--kind",
+    "operation",
+    "--input-shape",
+    "x",
+    "--output-shape",
+    "y",
+]
+
+
+def test_kind_choices_are_derived_from_the_domain_vocabulary() -> None:
+    """argparse restates nothing — its choices come from ``OutcomeKind``."""
+    from typing import get_args
+
+    from nwave_ai.outcomes.cli import _KIND_CHOICES
+    from nwave_ai.outcomes.domain.outcome import OutcomeKind
+
+    assert _KIND_CHOICES == get_args(OutcomeKind)
+
+
+def test_path_occupied_by_a_directory_is_named(tmp_path: Path) -> None:
+    occupied = tmp_path / "registry.yaml"
+    occupied.mkdir()
+
+    with pytest.raises(RegistryPathUnusableError) as err:
+        _ensure_registry(occupied)
+
+    assert str(occupied) in str(err.value)
+    assert "not a regular file" in str(err.value)
+
+
+def test_unwritable_parent_is_named(tmp_path: Path, monkeypatch) -> None:
+    """An OSError from the skeleton write surfaces as a named error, not a
+    traceback. Patched rather than chmod-driven so the test holds where the
+    suite runs as root and where chmod semantics differ."""
+    target = tmp_path / "ro" / "registry.yaml"
+
+    def _deny(*_args, **_kwargs):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(Path, "mkdir", _deny)
+
+    with pytest.raises(RegistryPathUnusableError) as err:
+        _ensure_registry(target)
+
+    assert str(target) in str(err.value)
+    assert "Permission denied" in str(err.value)
+
+
+def test_cli_exits_4_and_reports_instead_of_raising(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    occupied = tmp_path / "registry.yaml"
+    occupied.mkdir()
+
+    exit_code = handle_outcomes(["--registry", str(occupied), *_REGISTER_ARGV])
+
+    assert exit_code == 4
+    captured = capsys.readouterr()
+    assert "ERROR:" in captured.err
+    assert str(occupied) in captured.err

--- a/tests/outcomes/unit/test_schema_resource.py
+++ b/tests/outcomes/unit/test_schema_resource.py
@@ -1,0 +1,98 @@
+"""Unit test: the outcomes JSON Schema travels with the package.
+
+Regression guard for the `outcomes register` FileNotFoundError: the schema
+used to be resolved by walking OUT of the package
+(``Path(__file__).resolve().parents[3] / "docs" / ...``), which lands in
+``site-packages/docs/...`` in any real install, and the schema was shipped
+by no wheel include map.
+
+WHEN the outcomes registry validates an entry, the system SHALL load the
+schema as a resource of the ``nwave_ai.outcomes`` package.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from importlib import resources
+from pathlib import Path
+
+import yaml
+
+
+def test_schema_is_a_loadable_package_resource() -> None:
+    """The schema is readable via importlib.resources and is draft-07 JSON."""
+    raw = (
+        resources.files("nwave_ai.outcomes")
+        .joinpath("schema.json")
+        .read_text(encoding="utf-8")
+    )
+    schema = json.loads(raw)
+
+    assert schema["$schema"] == "http://json-schema.org/draft-07/schema#"
+    assert schema["properties"]["id"]["pattern"] == "^OUT-[A-Z0-9-]+$"
+
+
+def test_register_succeeds_in_installed_shape_without_repo_docs_tree(
+    tmp_path: Path,
+) -> None:
+    """Drive the real CLI from an installed-shape tree that has no ``docs/``.
+
+    Copies only the ``nwave_ai`` package into a bare directory that stands in
+    for ``site-packages`` and runs ``outcomes register`` from a project dir
+    outside the checkout. A source-tree run masks the defect entirely, so the
+    guard has to assert the installed shape.
+    """
+    repo_root = Path(__file__).resolve().parents[3]
+    site_packages = tmp_path / "site-packages"
+    shutil.copytree(
+        repo_root / "nwave_ai",
+        site_packages / "nwave_ai",
+        ignore=shutil.ignore_patterns("__pycache__"),
+    )
+    assert not (site_packages / "docs").exists()
+
+    project = tmp_path / "project"
+    project.mkdir()
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "nwave_ai.cli",
+            "outcomes",
+            "register",
+            "--id",
+            "OUT-1",
+            "--kind",
+            "operation",
+            "--input-shape",
+            "x",
+            "--output-shape",
+            "y",
+            "--feature",
+            "demo",
+            "--keywords",
+            "k",
+        ],
+        cwd=project,
+        env={
+            "PATH": "/usr/bin:/bin",
+            "PYTHONPATH": str(site_packages),
+            "HOME": str(tmp_path / "home"),
+        },
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+    assert completed.returncode == 0, (
+        f"register failed in installed shape: exit={completed.returncode}\n"
+        f"stdout={completed.stdout}\nstderr={completed.stderr}"
+    )
+    registry = project / "docs" / "product" / "outcomes" / "registry.yaml"
+    data = yaml.safe_load(registry.read_text(encoding="utf-8"))
+    assert [o["id"] for o in data["outcomes"]] == ["OUT-1"]

--- a/tests/outcomes/unit/test_schema_resource.py
+++ b/tests/outcomes/unit/test_schema_resource.py
@@ -16,6 +16,8 @@ import json
 import shutil
 import subprocess
 import sys
+
+import pytest
 from importlib import resources
 from pathlib import Path
 
@@ -96,3 +98,68 @@ def test_register_succeeds_in_installed_shape_without_repo_docs_tree(
     registry = project / "docs" / "product" / "outcomes" / "registry.yaml"
     data = yaml.safe_load(registry.read_text(encoding="utf-8"))
     assert [o["id"] for o in data["outcomes"]] == ["OUT-1"]
+
+
+class TestSchemaResourceFailureIsDiagnosable:
+    """A missing or corrupt schema resource must explain itself, not traceback.
+
+    The CLI advertises exit 3 with a reinstall hint for this case. Before these
+    tests that whole branch was unexercised — the improvement the change claims
+    was itself unverified.
+    """
+
+    def test_unreadable_resource_raises_a_named_error(self, monkeypatch):
+        """An OSError reading the resource becomes SchemaResourceUnavailableError."""
+        from nwave_ai.outcomes.application import registry_service
+
+        registry_service._load_validator.cache_clear()
+        monkeypatch.setattr(
+            registry_service.resources,
+            "files",
+            lambda _pkg: (_ for _ in ()).throw(OSError("disk gone")),
+        )
+        try:
+            with pytest.raises(registry_service.SchemaResourceUnavailableError) as err:
+                registry_service._load_validator()
+            assert "installation is incomplete" in str(err.value)
+        finally:
+            registry_service._load_validator.cache_clear()
+
+    def test_non_utf8_resource_raises_a_named_error(self, monkeypatch, tmp_path):
+        """UnicodeDecodeError is a ValueError, so an OSError-only clause misses it."""
+        from nwave_ai.outcomes.application import registry_service
+
+        class _BadBytes:
+            def joinpath(self, _name):
+                return self
+
+            def read_text(self, encoding="utf-8"):
+                raise UnicodeDecodeError(encoding, b"\xff\xfe", 0, 1, "invalid start byte")
+
+        registry_service._load_validator.cache_clear()
+        monkeypatch.setattr(registry_service.resources, "files", lambda _pkg: _BadBytes())
+        try:
+            with pytest.raises(registry_service.SchemaResourceUnavailableError):
+                registry_service._load_validator()
+        finally:
+            registry_service._load_validator.cache_clear()
+
+    def test_corrupt_json_resource_names_the_parse_failure(self, monkeypatch):
+        """A resource that is present but not JSON says so."""
+        from nwave_ai.outcomes.application import registry_service
+
+        class _NotJson:
+            def joinpath(self, _name):
+                return self
+
+            def read_text(self, encoding="utf-8"):
+                return "{not json"
+
+        registry_service._load_validator.cache_clear()
+        monkeypatch.setattr(registry_service.resources, "files", lambda _pkg: _NotJson())
+        try:
+            with pytest.raises(registry_service.SchemaResourceUnavailableError) as err:
+                registry_service._load_validator()
+            assert "not valid JSON" in str(err.value)
+        finally:
+            registry_service._load_validator.cache_clear()

--- a/tests/outcomes/unit/test_schema_resource.py
+++ b/tests/outcomes/unit/test_schema_resource.py
@@ -13,6 +13,7 @@ schema as a resource of the ``nwave_ai.outcomes`` package.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -80,8 +81,12 @@ def test_register_succeeds_in_installed_shape_without_repo_docs_tree(
             "k",
         ],
         cwd=project,
+        # Inherit the running interpreter's environment rather than asserting a
+        # POSIX layout ("/usr/bin:/bin" is wrong on Windows and on Nix). The
+        # isolation this test needs is PYTHONPATH + cwd, both overridden below;
+        # nothing else in the parent environment can point back at the checkout.
         env={
-            "PATH": "/usr/bin:/bin",
+            **os.environ,
             "PYTHONPATH": str(site_packages),
             "HOME": str(tmp_path / "home"),
         },

--- a/tests/outcomes/unit/test_schema_validation.py
+++ b/tests/outcomes/unit/test_schema_validation.py
@@ -1,6 +1,7 @@
 """Unit test: JSON Schema validates registry entries.
 
-Loads docs/product/outcomes/schema.json (draft-07) and asserts:
+Loads the packaged schema resource ``nwave_ai/outcomes/schema.json``
+(draft-07) and asserts:
 - a valid canonical entry passes
 - entries missing required fields fail
 - entries with invalid kind/id pattern fail
@@ -9,19 +10,18 @@ Loads docs/product/outcomes/schema.json (draft-07) and asserts:
 from __future__ import annotations
 
 import json
-from pathlib import Path
+from importlib import resources
 
 import pytest
 from jsonschema import Draft7Validator, ValidationError
 
 
-_SCHEMA_PATH = (
-    Path(__file__).parents[3] / "docs" / "product" / "outcomes" / "schema.json"
-)
-
-
 def _load_schema() -> dict:
-    return json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    return json.loads(
+        resources.files("nwave_ai.outcomes")
+        .joinpath("schema.json")
+        .read_text(encoding="utf-8")
+    )
 
 
 def _valid_entry() -> dict:

--- a/tests/outcomes/unit/test_schema_validation.py
+++ b/tests/outcomes/unit/test_schema_validation.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 from importlib import resources
+from typing import get_args
 
 import pytest
 from jsonschema import Draft7Validator, ValidationError
@@ -69,6 +70,20 @@ def test_invalid_entries_fail_schema(
     assert expected_path_fragment in str(exc.value), (
         f"expected '{expected_path_fragment}' in error: {exc.value}"
     )
+
+
+def test_schema_kind_enum_agrees_with_the_domain_literal() -> None:
+    """The schema enum and ``OutcomeKind`` are one vocabulary, not two.
+
+    ``nwave_ai/outcomes/cli.py`` derives its argparse ``choices`` from
+    ``OutcomeKind`` directly, so it cannot drift. The schema is static JSON
+    shipped in the wheel and cannot derive anything at runtime — this test is
+    what keeps it pinned. Adding a fourth kind fails here until the enum in
+    ``schema.json`` is updated too.
+    """
+    from nwave_ai.outcomes.domain.outcome import OutcomeKind
+
+    assert tuple(_load_schema()["properties"]["kind"]["enum"]) == get_args(OutcomeKind)
 
 
 def test_missing_required_field_fails_schema() -> None:


### PR DESCRIPTION
## Why

`nwave-ai outcomes register` could not work from any real install. The validator resolved its JSON Schema by walking **out** of the installed package — `Path(__file__).resolve().parents[3] / "docs" / "product" / "outcomes" / "schema.json"` — which lands inside `site-packages/docs/…` once installed. The schema was also not shipped by any wheel include map, so there was nothing at the end of that path to find. `outcomes check` was unaffected because only the write path builds the validator, which is why the read side appeared healthy while registering was impossible and the registry had to be hand-written.

In this repository the situation is worse than #63 describes: `docs/product/outcomes/schema.json` does not exist **at all** — `docs/` is stripped by the public release sync — so `tests/outcomes/` could not pass here either.

## What changed

- `nwave_ai/outcomes/schema.json` — the schema now lives inside the package. Its contract is derived from what the existing tests already assert (`^OUT-[A-Z0-9-]+$` id pattern, required fields, `kind` enum); no fields were invented.
- `nwave_ai/outcomes/application/registry_service.py` — loads it via `importlib.resources`. The `parents[…]` walk-out is deleted outright, not patched.
- `nwave_ai/outcomes/cli.py` — a missing schema resource now produces a named error and a non-zero exit with a message that explains itself, instead of a bare `FileNotFoundError` traceback.
- `tests/outcomes/unit/test_schema_resource.py`, `tests/outcomes/unit/test_schema_validation.py` — assert the resource loads, and guard against the walk-out pattern returning.

## Why a package resource rather than a project file

The schema is a tool-owned contract, not per-project configuration: the code validates against it unconditionally and nothing reads a project-local override. Making it a package resource is also what `nWave-ai/nWave-experimental` already does — its `registry_service.py` documents exactly this, in these words:

> The schema is a PACKAGE RESOURCE, loaded via `importlib.resources`: it … rather than walking out of the package (`__file__.parents[n] / "docs" / ...`)

This PR brings the stable track in line with that resolution rather than inventing a third one.

## Test plan

- `./.venv/bin/python -m pytest tests/outcomes -q` — **24 failures at base → 1 at head**, within the same worktree and virtualenv. The RED proof is direct: reverting the two source files and deleting the schema puts 24 tests back to red, including the whole `test_us1_register.py` and `test_us2_check.py` sets.
- The single remaining failure, `test_seed_registry.py::…_for_oute3`, fails identically at base and at head. It is pre-existing and untouched by this change.
- Confirmed `nwave_ai/outcomes/schema.json` is git-tracked and sits inside the `packages = ["nwave_ai"]` tree, so hatchling ships it in the wheel without a `force-include` entry.
- Not tested: an actual `pip install` of the built wheel followed by `outcomes register` outside a checkout. The resource-loading test covers the mechanism, but not the packaging end-to-end.

## Focus areas

- **The schema's content.** It was reconstructed from the assertions in `tests/outcomes/`, since no copy exists in this repository. If the canonical schema differs — extra optional fields, a wider `kind` enum, a different `$schema` draft — this file is the thing to correct, and it is worth diffing against whatever the private tree holds.
- **Whether `docs/product/outcomes/schema.json` should still exist** as a human-readable copy, and if so whether it should be generated from the package resource rather than maintained separately. This PR does not restore it.
- `jsonschema` is imported at `registry_service.py` but does not appear to be a declared runtime dependency (#60). This PR does not address that; a clean install may still fail at the import before ever reaching the schema.

## Risk / rollback

Blast radius is the `outcomes register` write path only; `check` and `load` are untouched. The change strictly widens what works — the previous behaviour was an unconditional crash in any install.

Revert with `git revert <sha>`. No data migration: existing `registry.yaml` files are unaffected, since only validation changed, not the persisted format.

Closes #63
