### PR TITLE
fix(density): validate and document expansion_prompt values

### DIFF
--- a/docs/guides/configuring-doc-density.md
+++ b/docs/guides/configuring-doc-density.md
@@ -124,6 +124,31 @@ Or explicitly:
 
 ---
 
+### Use case 4: I want a scoped expansion menu (`ask-intelligent`)
+
+**Situation**: The full `ask` menu lists every Tier-2 expansion in the catalog, most of which are irrelevant to the wave you just ran. You want to be offered only what this wave actually surfaced.
+
+**Solution**:
+
+```json
+{
+  "documentation": {
+    "expansion_prompt": "ask-intelligent"
+  }
+}
+```
+
+**This is the fresh-install default** (Decision 4, 2026-04-28). A fresh `nwave-ai install` writes `"expansion_prompt": "ask-intelligent"` into `~/.nwave/global-config.json`, and it is also the value the resolver falls back to when neither `documentation.expansion_prompt` nor `rigor.profile` is set.
+
+**Result**:
+- **WHEN** a wave ends, the system **SHALL** show a menu containing only those Tier-2 expansions whose trigger fired during that wave — not the whole catalog.
+- **WHERE** no trigger fired, no menu is shown and the wave ends at its lean baseline.
+- Trigger detection lives in the wave skill prose, not in the density resolver.
+
+**Accepted values**: `ask`, `ask-intelligent`, `always-skip`, `always-expand`, `smart`. **IF** `documentation.expansion_prompt` holds anything else, the density resolver **SHALL** reject the configuration with an error naming the accepted values, rather than silently ignoring the setting.
+
+---
+
 ## Ad-hoc expansion (override at wave time)
 
 Even with `density: "lean"` and `expansion_prompt: "always-skip"`, you can request more detail during a specific wave **without** changing your global config.
@@ -144,7 +169,7 @@ When running a wave, pass the `--expand` flag with a comma-separated list of exp
 
 ### Method 2: Respond to the wave-end prompt
 
-If `expansion_prompt: "ask"`:
+If `expansion_prompt` is `"ask"` (full catalog) or `"ask-intelligent"` (only triggered items):
 
 ```bash
 /nw-discuss my-complex-feature
@@ -196,10 +221,12 @@ Your `rigor` profile affects the default density if you don't explicitly set `do
 | Profile | If `density` unset | If `density` unset |
 |---------|---|---|
 | `lean` | → density: `"lean"` | → expansion_prompt: `"always-skip"` |
-| `standard` | → density: `"lean"` | → expansion_prompt: `"ask"` |
+| `standard` | → density: `"lean"` | → expansion_prompt: `"ask-intelligent"` |
 | `thorough` | → density: `"full"` | → expansion_prompt: `"always-expand"` |
 | `exhaustive` | → density: `"full"` | → expansion_prompt: `"always-expand"` |
-| `custom` | → density: `"lean"` (fallback) | → expansion_prompt: `"ask"` (fallback) |
+| `custom` | → density: `"lean"` (fallback) | → expansion_prompt: `"ask-intelligent"` (fallback) |
+
+**No `rigor.profile`, no `documentation` block** (fresh install): density `"lean"`, expansion_prompt `"ask-intelligent"`.
 
 **What this means**:
 
@@ -292,7 +319,7 @@ Pick one. It's saved and never prompted again (idempotent).
 
 ### Q: What if I'm running in CI (non-interactive)?
 
-**A**: When there's no terminal (TTY), interactive prompts are skipped. nWave defaults to `always-skip` behavior for expansions, even if `expansion_prompt: "ask"` is set. Lean output is still produced. To include specific expansions in CI:
+**A**: When there's no terminal (TTY), interactive prompts are skipped. nWave defaults to `always-skip` behavior for expansions, even if `expansion_prompt` is `"ask"` or `"ask-intelligent"`. Lean output is still produced. To include specific expansions in CI:
 
 ```bash
 /nw-discuss my-feature --expand jtbd-narrative

--- a/docs/reference/global-config.md
+++ b/docs/reference/global-config.md
@@ -124,9 +124,13 @@ Specifies the default detail level for wave output. Valid values: `lean`, `full`
 
 #### `documentation.expansion_prompt` (string, optional)
 
-Controls when wave end prompts offer optional expansions (JTBD narrative, alternatives, migration playbooks, etc.). Valid values: `ask`, `always-skip`, `always-expand`, `smart`.
+Controls when wave end prompts offer optional expansions (JTBD narrative, alternatives, migration playbooks, etc.). Valid values: `ask`, `ask-intelligent`, `always-skip`, `always-expand`, `smart`.
 
-- **`ask`**: (Default) At the end of each wave, prompt the user with a menu of available expansions. User can select one-shot additions without re-running the wave.
+**IF** `documentation.expansion_prompt` holds a value outside that set, the density resolver **SHALL** reject the configuration with an error naming the accepted values.
+
+- **`ask`**: At the end of each wave, prompt the user with a menu of all available expansions. User can select one-shot additions without re-running the wave.
+
+- **`ask-intelligent`**: (Fresh-install default since Decision 4, 2026-04-28) At the end of each wave, prompt the user with a **scoped** menu instead of the full catalog: only those Tier-2 items whose trigger fired during the wave are offered. Trigger detection lives in the wave skill prose, not in the resolver. **WHERE** no trigger fired, no menu is shown.
 
 - **`always-skip`**: Never prompt; skip all expansions. Equivalent to always pressing "skip all" at the menu. Useful for fully automated / CI flows where user input is not expected.
 
@@ -136,10 +140,11 @@ Controls when wave end prompts offer optional expansions (JTBD narrative, altern
 
 **Default behavior** (if key absent):
 - If `rigor.profile` is `lean`, inherit `always-skip`.
-- If `rigor.profile` is `standard` or `custom`, inherit `ask`.
+- If `rigor.profile` is `standard` or `custom`, inherit `ask-intelligent`.
 - If `rigor.profile` is `thorough` or `exhaustive`, inherit `always-expand`.
+- If neither key is present (fresh install), the hard default is `ask-intelligent`.
 
-**Note on interactivity**: When `expansion_prompt: "ask"`, the wave reaches an interactive prompt at the end. This requires a terminal (TTY). Non-interactive runs (e.g., CI pipelines) default to `always-skip` behavior.
+**Note on interactivity**: When `expansion_prompt` is `ask` or `ask-intelligent`, the wave reaches an interactive prompt at the end. This requires a terminal (TTY). Non-interactive runs (e.g., CI pipelines) default to `always-skip` behavior.
 
 **Example**:
 ```json

--- a/nWave/skills/nw-density-resolution-contract/SKILL.md
+++ b/nWave/skills/nw-density-resolution-contract/SKILL.md
@@ -34,7 +34,7 @@ Before emitting any Tier-1 section, resolve the active documentation density:
    - `"always-expand"` → equivalent to `mode = "full"` for this run; auto-render every Tier-2 item.
    - `"smart"` → out of scope for v1 (per OQ-3); treat as `"ask"` until heuristic is empirically tuned.
 
-The resolver itself encodes the D12 cascade: explicit `documentation.density` override > `rigor.profile` mapping (`lean`→`lean`, `standard`→`lean`+`ask`, `thorough`→`full`, `exhaustive`→`full`+all-expansions, `custom`→`lean`+`ask`) > hard default `lean`+`ask`. Wave skills MUST NOT replicate the cascade locally — call `resolve_density(global_config)` and trust its output.
+The resolver itself encodes the D12 cascade: explicit `documentation.density` override > `rigor.profile` mapping (`lean`→`lean`, `standard`→`lean`+`ask-intelligent`, `thorough`→`full`, `exhaustive`→`full`+all-expansions, `custom`→`lean`+`ask-intelligent`) > hard default `lean`+`ask-intelligent`. **WHERE** `documentation.expansion_prompt` is set explicitly, it overrides the prompt in every branch, including the `rigor.profile` and hard-default branches. Wave skills MUST NOT replicate the cascade locally — call `resolve_density(global_config)` and trust its output.
 
 **Section heading prefix convention (per D2)**: every emitted section starts with `## Wave: <NAME> / [REF] <Section>` for Tier-1; `## Wave: <NAME> / [WHY] <Section>` or `## Wave: <NAME> / [HOW] <Section>` for Tier-2. Validator `scripts/validation/validate_feature_delta.py` enforces the regex `^## Wave: \w+ / \[(REF|WHY|HOW)\] .+$` on every wave heading.
 

--- a/nWave/skills/nw-density-resolution-contract/SKILL.md
+++ b/nWave/skills/nw-density-resolution-contract/SKILL.md
@@ -16,19 +16,20 @@ Provenance: feature `lean-wave-documentation` — D2 (schema-typed sections), D4
 Each wave emits a single `feature-delta.md` whose headings are typed `[REF]` (always emitted) or `[WHY]/[HOW]` (lazy expansions). Tier-1 is the always-on baseline; Tier-2 is the lazily-rendered expansion catalog. The `.feature` file (DISTILL) and other machine artifacts remain the SSOT for executable content; the wave-delta sections are pointers + structured summaries.
 
 - **Tier-1 [REF]** — emitted under `## Wave: <NAME> / [REF] <Section>` headings on every run. Wave-specific list of `[REF]` sections lives in each wave skill.
-- **Tier-2 EXPANSION CATALOG** — NOT emitted by default. Rendered only when explicitly requested via `--expand <id>` (DDD-2) or via the wave-end interactive prompt when `expansion_prompt = "ask"`. Each item has a one-line description (per D10) so the menu fits in a single render. Each emitted Tier-2 section is headed `## Wave: <NAME> / [WHY] <Section>` or `## Wave: <NAME> / [HOW] <Section>`. The catalog itself is wave-specific.
+- **Tier-2 EXPANSION CATALOG** — NOT emitted by default. Rendered only when explicitly requested via `--expand <id>` (DDD-2) or via the wave-end interactive prompt when `expansion_prompt` is `"ask"` or `"ask-intelligent"`. Each item has a one-line description (per D10) so the menu fits in a single render. Each emitted Tier-2 section is headed `## Wave: <NAME> / [WHY] <Section>` or `## Wave: <NAME> / [HOW] <Section>`. The catalog itself is wave-specific.
 
 ## Density resolution (per D12)
 
 Before emitting any Tier-1 section, resolve the active documentation density:
 
 1. **Read** `~/.nwave/global-config.json`. Treat missing/malformed config as empty dict (fall back to defaults).
-2. **Call** `resolve_density(global_config)` from `scripts/shared/density_config.py`. The function returns a `Density` value object with fields `mode` (`"lean"` | `"full"`), `expansion_prompt` (`"ask"` | `"always-skip"` | `"always-expand"` | `"smart"`), and `provenance` (the cascade branch that produced this result).
+2. **Call** `resolve_density(global_config)` from `scripts/shared/density_config.py`. The function returns a `Density` value object with fields `mode` (`"lean"` | `"full"`), `expansion_prompt` (`"ask"` | `"ask-intelligent"` | `"always-skip"` | `"always-expand"` | `"smart"`), and `provenance` (the cascade branch that produced this result).
 3. **Branch on `density.mode`**:
    - `lean` → emit ONLY Tier-1 `[REF]` sections. Do NOT auto-render Tier-2 items.
    - `full` → emit Tier-1 `[REF]` sections PLUS all Tier-2 expansion items rendered under their `[WHY]` / `[HOW]` headings. This is auto-expansion (no menu).
 4. **At wave end**, branch on `density.expansion_prompt`:
    - `"ask"` → present the expansion menu (Tier-2 catalog with one-line descriptions per D10) and append user-selected items as `## Wave: <NAME> / [WHY|HOW] <Section>` headings.
+   - `"ask-intelligent"` → the fresh-install default. **WHEN** the wave ends, the system SHALL present a scoped menu holding only those Tier-2 catalog items whose trigger fired during this wave. **WHERE** no trigger fired, the system SHALL present no menu.
    - `"always-skip"` → no menu, no extra sections (idempotent re-runs, CI mode).
    - `"always-expand"` → equivalent to `mode = "full"` for this run; auto-render every Tier-2 item.
    - `"smart"` → out of scope for v1 (per OQ-3); treat as `"ask"` until heuristic is empirically tuned.
@@ -83,7 +84,7 @@ The wave-skill harness invokes the helper `scripts/shared/telemetry.py:write_den
 
 **When to emit**:
 
-- One event per user choice in the expansion menu when `expansion_prompt = "ask"` (`choice = "expand"` for selected items, `choice = "skip"` with `expansion_id = "*"` if the user skips the entire menu).
+- One event per user choice in the expansion menu when `expansion_prompt` is `"ask"` or `"ask-intelligent"` (`choice = "expand"` for selected items, `choice = "skip"` with `expansion_id = "*"` if the user skips the entire menu).
 - One synthetic `choice = "skip"` event with `expansion_id = "*"` when `expansion_prompt = "always-skip"` (records the skipped menu opportunity).
 - One `choice = "expand"` event per Tier-2 item rendered when `mode = "full"` or `expansion_prompt = "always-expand"`.
 

--- a/nwave_ai/doctor/checks/density.py
+++ b/nwave_ai/doctor/checks/density.py
@@ -105,14 +105,18 @@ class DensityCheck:
             return CheckResult(
                 passed=False,
                 error_code="DENSITY_RESOLUTION_FAILED",
-                message=(
-                    "Documentation density could not be resolved: "
-                    f"{exc}. Check `rigor.profile` in ~/.nwave/global-config.json."
-                ),
+                # The resolver raises for more than one reason now (bad
+                # rigor.profile, bad documentation.expansion_prompt, a
+                # non-object config section). Hardcoding a rigor.profile
+                # diagnosis would misdirect the user for every other cause, so
+                # the resolver's own message — which names the offending key
+                # and its accepted values — is the diagnosis.
+                message=f"Documentation density could not be resolved: {exc}",
                 remediation=(
-                    "Set `rigor.profile` to one of: lean, standard, thorough, "
-                    "exhaustive, custom — or set `documentation.density` "
-                    "explicitly to 'lean' or 'full'."
+                    "Correct the key named above in ~/.nwave/global-config.json. "
+                    "`rigor.profile` accepts: lean, standard, thorough, "
+                    "exhaustive, custom. `documentation.density` accepts 'lean' "
+                    "or 'full'."
                 ),
             )
         return CheckResult(

--- a/scripts/shared/density_config.py
+++ b/scripts/shared/density_config.py
@@ -102,21 +102,42 @@ def _from_rigor_profile(profile: str) -> Density:
     )
 
 
+_ABSENT = object()
+
+
 def _validate_expansion_prompt(value: Any) -> None:
     """Reject a `documentation.expansion_prompt` outside the accepted set.
 
-    A missing key is valid — the cascade supplies a default. Any present value
-    that is not one of `_ACCEPTED_EXPANSION_PROMPTS` raises ValueError naming
-    the accepted set, so a typo surfaces as a fixable error instead of a
-    silent no-op.
+    An ABSENT key is valid — the cascade supplies a default. A key that is
+    PRESENT must carry an accepted value, and that includes an explicit JSON
+    `null`: `{"expansion_prompt": null}` is a configuration mistake, not a way
+    to request the default, and treating it as absent lets `None` reach the
+    resolved Density.
     """
-    if value is None:
+    if value is _ABSENT:
         return
     if value not in _ACCEPTED_EXPANSION_PROMPTS:
         raise ValueError(
             f"Unknown documentation.expansion_prompt {value!r}; "
             f"expected one of {list(_ACCEPTED_EXPANSION_PROMPTS)}."
         )
+
+
+def _section(global_config: dict[str, Any], key: str) -> dict[str, Any]:
+    """Return a mapping section of the config, or raise naming the offender.
+
+    `global_config.get(key, {})` assumes the value is a dict. A scalar or list
+    there raises AttributeError several lines later, which reaches the user as
+    an internal error rather than as "your config is malformed, and here is
+    where".
+    """
+    section = global_config.get(key, {})
+    if not isinstance(section, dict):
+        raise ValueError(
+            f"Config key {key!r} must be an object, got "
+            f"{type(section).__name__}: {section!r}."
+        )
+    return section
 
 
 def resolve_density(global_config: dict[str, Any]) -> Density:
@@ -147,28 +168,47 @@ def resolve_density(global_config: dict[str, Any]) -> Density:
     # Step 0: reject an unrecognised expansion_prompt outright. Without this
     # the value is silently carried (or silently ignored), leaving the user no
     # signal that their setting does nothing.
-    documentation = global_config.get("documentation", {})
-    _validate_expansion_prompt(documentation.get("expansion_prompt"))
+    documentation = _section(global_config, "documentation")
+    explicit_prompt = documentation.get("expansion_prompt", _ABSENT)
+    _validate_expansion_prompt(explicit_prompt)
+
+    # An explicitly-set expansion_prompt is honoured by EVERY branch below, not
+    # only by the explicit-density branch. Validating a value and then
+    # discarding it in two of three branches would leave the user's setting a
+    # silent no-op — the very complaint issue #84 records — while adding the
+    # appearance of strictness.
+    def _with_explicit_prompt(density: Density) -> Density:
+        if explicit_prompt is _ABSENT:
+            return density
+        if density.expansion_prompt == explicit_prompt:
+            return density
+        return Density(
+            mode=density.mode,
+            expansion_prompt=explicit_prompt,
+            provenance=f"{density.provenance}+explicit_expansion_prompt",
+        )
 
     # Step 1: explicit override wins — both density and expansion_prompt.
     explicit_mode = documentation.get("density")
     if explicit_mode is not None:
         return Density(
             mode=explicit_mode,
-            expansion_prompt=documentation.get("expansion_prompt", "ask-intelligent"),
+            expansion_prompt=(
+                explicit_prompt if explicit_prompt is not _ABSENT else "ask-intelligent"
+            ),
             provenance="explicit_override",
         )
 
     # Step 2: rigor.profile inheritance per D12.
-    rigor_profile = global_config.get("rigor", {}).get("profile")
+    rigor_profile = _section(global_config, "rigor").get("profile")
     if rigor_profile is not None:
-        return _from_rigor_profile(rigor_profile)
+        return _with_explicit_prompt(_from_rigor_profile(rigor_profile))
 
     # Step 3: hard default — fresh install, no documentation, no rigor.
     # Per Decision 4 (2026-04-28), the fresh-install default is
     # ("lean", "ask-intelligent"): emit minimal Tier-1 baseline, then
     # show a scoped expansion menu only when triggers fire (the wave
     # skill prose owns trigger detection).
-    return Density(
-        mode="lean", expansion_prompt="ask-intelligent", provenance="default"
+    return _with_explicit_prompt(
+        Density(mode="lean", expansion_prompt="ask-intelligent", provenance="default")
     )

--- a/scripts/shared/density_config.py
+++ b/scripts/shared/density_config.py
@@ -30,6 +30,17 @@ ExpansionPromptMode = Literal[
     "ask", "always-skip", "always-expand", "smart", "ask-intelligent"
 ]
 
+# Accepted `documentation.expansion_prompt` values, in documentation order.
+# Kept in sync with `ExpansionPromptMode` and with
+# `docs/reference/global-config.md` / `docs/guides/configuring-doc-density.md`.
+_ACCEPTED_EXPANSION_PROMPTS: tuple[str, ...] = (
+    "ask",
+    "always-skip",
+    "always-expand",
+    "smart",
+    "ask-intelligent",
+)
+
 
 @dataclass(frozen=True)
 class Density:
@@ -91,6 +102,23 @@ def _from_rigor_profile(profile: str) -> Density:
     )
 
 
+def _validate_expansion_prompt(value: Any) -> None:
+    """Reject a `documentation.expansion_prompt` outside the accepted set.
+
+    A missing key is valid — the cascade supplies a default. Any present value
+    that is not one of `_ACCEPTED_EXPANSION_PROMPTS` raises ValueError naming
+    the accepted set, so a typo surfaces as a fixable error instead of a
+    silent no-op.
+    """
+    if value is None:
+        return
+    if value not in _ACCEPTED_EXPANSION_PROMPTS:
+        raise ValueError(
+            f"Unknown documentation.expansion_prompt {value!r}; "
+            f"expected one of {list(_ACCEPTED_EXPANSION_PROMPTS)}."
+        )
+
+
 def resolve_density(global_config: dict[str, Any]) -> Density:
     """Return the active documentation density via the D12 cascade.
 
@@ -113,10 +141,16 @@ def resolve_density(global_config: dict[str, Any]) -> Density:
         and provenance.
 
     Raises:
-        ValueError: rigor.profile is set to an unknown value.
+        ValueError: rigor.profile is set to an unknown value, or
+            documentation.expansion_prompt is outside the accepted set.
     """
-    # Step 1: explicit override wins — both density and expansion_prompt.
+    # Step 0: reject an unrecognised expansion_prompt outright. Without this
+    # the value is silently carried (or silently ignored), leaving the user no
+    # signal that their setting does nothing.
     documentation = global_config.get("documentation", {})
+    _validate_expansion_prompt(documentation.get("expansion_prompt"))
+
+    # Step 1: explicit override wins — both density and expansion_prompt.
     explicit_mode = documentation.get("density")
     if explicit_mode is not None:
         return Density(

--- a/scripts/shared/density_config.py
+++ b/scripts/shared/density_config.py
@@ -22,7 +22,7 @@ re-running the cascade.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any, Literal, get_args
 
 
 DensityMode = Literal["lean", "full"]
@@ -30,16 +30,13 @@ ExpansionPromptMode = Literal[
     "ask", "always-skip", "always-expand", "smart", "ask-intelligent"
 ]
 
-# Accepted `documentation.expansion_prompt` values, in documentation order.
-# Kept in sync with `ExpansionPromptMode` and with
-# `docs/reference/global-config.md` / `docs/guides/configuring-doc-density.md`.
-_ACCEPTED_EXPANSION_PROMPTS: tuple[str, ...] = (
-    "ask",
-    "always-skip",
-    "always-expand",
-    "smart",
-    "ask-intelligent",
-)
+# Accepted `documentation.expansion_prompt` values, derived from the type so the
+# runtime check and the type annotation cannot disagree. A restatement kept in
+# sync by comment would let a value added to `ExpansionPromptMode` type-check
+# clean while the resolver rejected it at runtime — the worst pairing.
+# `get_args` preserves declaration order, so the error message still lists the
+# values in documentation order.
+_ACCEPTED_EXPANSION_PROMPTS: tuple[str, ...] = get_args(ExpansionPromptMode)
 
 
 @dataclass(frozen=True)

--- a/tests/des/unit/shared/test_density_config.py
+++ b/tests/des/unit/shared/test_density_config.py
@@ -117,7 +117,52 @@ def test_unknown_expansion_prompt_error_names_accepted_values() -> None:
         assert accepted in message
 
 
-def test_known_expansion_prompt_without_density_is_accepted() -> None:
-    """A recognised expansion_prompt alone does not raise."""
+def test_known_expansion_prompt_without_density_is_accepted_and_applied() -> None:
+    """A recognised expansion_prompt alone is accepted AND takes effect.
+
+    Asserting only the provenance would let this pass while the user's value was
+    silently discarded, which is the defect issue #84 records.
+    """
     config = {"documentation": {"expansion_prompt": "smart"}}
-    assert resolve_density(config).provenance == "default"
+    density = resolve_density(config)
+
+    assert density.expansion_prompt == "smart"
+    assert density.mode == "lean"
+
+
+def test_explicit_expansion_prompt_survives_rigor_profile_inheritance():
+    """WHEN expansion_prompt is set without density, the value SHALL take effect.
+
+    Validating a value and then discarding it is the silent no-op issue #84
+    records, dressed up as strictness.
+    """
+    density = resolve_density(
+        {"documentation": {"expansion_prompt": "always-skip"}, "rigor": {"profile": "thorough"}}
+    )
+
+    assert density.expansion_prompt == "always-skip"
+    assert "explicit_expansion_prompt" in density.provenance
+
+
+def test_explicit_expansion_prompt_survives_the_hard_default():
+    """The same holds with neither density nor rigor.profile present."""
+    density = resolve_density({"documentation": {"expansion_prompt": "always-expand"}})
+
+    assert density.expansion_prompt == "always-expand"
+    assert density.mode == "lean", "only the prompt is overridden, not the density"
+
+
+def test_explicit_null_expansion_prompt_is_rejected():
+    """An explicit JSON null is a mistake, not a request for the default.
+
+    `.get(key, default)` returns the stored None when the key is present, so
+    treating null as absent lets None reach the resolved Density.
+    """
+    with pytest.raises(ValueError, match="expansion_prompt"):
+        resolve_density({"documentation": {"expansion_prompt": None}})
+
+
+def test_non_object_documentation_section_names_the_offender():
+    """A malformed section raises ValueError, not AttributeError."""
+    with pytest.raises(ValueError, match="documentation"):
+        resolve_density({"documentation": "lean"})

--- a/tests/des/unit/shared/test_density_config.py
+++ b/tests/des/unit/shared/test_density_config.py
@@ -92,3 +92,32 @@ def test_unknown_rigor_profile_raises_value_error() -> None:
     config = {"rigor": {"profile": "ludicrous"}}
     with pytest.raises(ValueError, match="ludicrous"):
         resolve_density(config)
+
+
+def test_unknown_expansion_prompt_raises_value_error() -> None:
+    """Strict: an unrecognised expansion_prompt is rejected, not silently kept."""
+    config = {"documentation": {"density": "lean", "expansion_prompt": "sometimes"}}
+    with pytest.raises(ValueError, match="sometimes"):
+        resolve_density(config)
+
+
+def test_unknown_expansion_prompt_error_names_accepted_values() -> None:
+    """The rejection message enumerates the accepted expansion_prompt set."""
+    config = {"documentation": {"expansion_prompt": "sometimes"}}
+    with pytest.raises(ValueError) as excinfo:
+        resolve_density(config)
+    message = str(excinfo.value)
+    for accepted in (
+        "ask",
+        "always-skip",
+        "always-expand",
+        "smart",
+        "ask-intelligent",
+    ):
+        assert accepted in message
+
+
+def test_known_expansion_prompt_without_density_is_accepted() -> None:
+    """A recognised expansion_prompt alone does not raise."""
+    config = {"documentation": {"expansion_prompt": "smart"}}
+    assert resolve_density(config).provenance == "default"

--- a/tests/des/unit/shared/test_density_config.py
+++ b/tests/des/unit/shared/test_density_config.py
@@ -19,9 +19,17 @@ Coverage (per task spec):
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
+from typing import get_args
+
 import pytest
 
-from scripts.shared.density_config import Density, resolve_density
+from scripts.shared.density_config import (
+    Density,
+    ExpansionPromptMode,
+    resolve_density,
+)
 
 
 def test_empty_config_returns_lean_default() -> None:
@@ -166,3 +174,105 @@ def test_non_object_documentation_section_names_the_offender():
     """A malformed section raises ValueError, not AttributeError."""
     with pytest.raises(ValueError, match="documentation"):
         resolve_density({"documentation": "lean"})
+
+
+# --- documented vocabulary ------------------------------------------------
+#
+# `_ACCEPTED_EXPANSION_PROMPTS` now derives from `ExpansionPromptMode` via
+# `get_args`, so code cannot drift from itself. Prose cannot derive — the three
+# documents below restate the vocabulary for human readers, and that
+# restatement drifting from the type IS the defect issue #84 records:
+# `ask-intelligent` was accepted by the resolver while no document listed it.
+# These tests are the gate that would have caught it.
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+
+# Each doc is addressed by a markdown section plus the enumerating phrase inside
+# it, never a line number, so the tests survive reflow, reordering, and edits
+# elsewhere in the page. Both documents enumerate other vocabularies too
+# (`rigor.profile`, `update_check`), hence the section scoping. A moved anchor
+# fails loudly with an instruction rather than silently passing.
+_ENUMERATION_ANCHORS = (
+    (
+        "docs/reference/global-config.md",
+        "#### `documentation.expansion_prompt`",
+        "Valid values:",
+    ),
+    (
+        "docs/guides/configuring-doc-density.md",
+        "### Use case 4",
+        "**Accepted values**:",
+    ),
+)
+
+
+def _section_lines(text: str, heading_prefix: str) -> list[str]:
+    """Return the lines of the markdown section opened by `heading_prefix`."""
+    lines = text.splitlines()
+    starts = [i for i, line in enumerate(lines) if line.startswith(heading_prefix)]
+    if not starts:
+        return []
+    start = starts[0]
+    for offset, line in enumerate(lines[start + 1 :], start=start + 1):
+        if line.startswith("#"):
+            return lines[start:offset]
+    return lines[start:]
+
+
+def _backticked_values_after(line: str, anchor: str) -> set[str]:
+    """Return the bare backticked value tokens following `anchor` on `line`.
+
+    Filtered to lowercase/hyphen tokens so incidental backticked prose in the
+    same sentence (`documentation.expansion_prompt`, `--expand`) is not mistaken
+    for a listed value.
+    """
+    tail = line.split(anchor, 1)[1]
+    return {
+        token
+        for token in re.findall(r"`([^`]+)`", tail)
+        if re.fullmatch(r"[a-z][a-z-]*", token)
+    }
+
+
+@pytest.mark.parametrize(("relative_path", "heading", "anchor"), _ENUMERATION_ANCHORS)
+def test_documented_expansion_prompt_enumeration_matches_the_type(
+    relative_path: str, heading: str, anchor: str
+) -> None:
+    """Each doc's enumerating sentence lists exactly the accepted values."""
+    text = (_REPO_ROOT / relative_path).read_text(encoding="utf-8")
+    section = _section_lines(text, heading)
+    assert section, (
+        f"section {heading!r} not found in {relative_path}; it was renamed or "
+        "removed — update this test's heading anchor."
+    )
+
+    matching = [line for line in section if anchor in line]
+    assert matching, (
+        f"phrase {anchor!r} not found under {heading!r} in {relative_path}; the "
+        "enumerating sentence moved or was reworded — update this test's anchor."
+    )
+
+    documented: set[str] = set()
+    for line in matching:
+        documented |= _backticked_values_after(line, anchor)
+
+    assert documented == set(get_args(ExpansionPromptMode))
+
+
+def test_resolution_contract_skill_mentions_every_accepted_value() -> None:
+    """The contract skill has no single enumerating sentence to anchor on.
+
+    It threads the values through per-value bullets and a cascade paragraph, so
+    the gate here is presence rather than set equality: every accepted value is
+    described somewhere. That catches the #84 direction (a value the contract
+    never mentions); the converse — prose naming a value the type dropped — is
+    left to the two enumeration tests above, which do check equality.
+    """
+    text = (
+        _REPO_ROOT / "nWave/skills/nw-density-resolution-contract/SKILL.md"
+    ).read_text(encoding="utf-8")
+
+    missing = [
+        value for value in get_args(ExpansionPromptMode) if f'`"{value}"`' not in text
+    ]
+    assert not missing, f"undocumented in the resolution contract: {missing}"


### PR DESCRIPTION
## Why

A fresh install writes `documentation.expansion_prompt: ask-intelligent` into the user's config, but both documentation pages describing that setting list only four accepted values — and `ask-intelligent` is not among them. The one value every new user is actually given is the one value they cannot look up. Nothing validated the field either, so a typo was accepted in silence and simply fell through to default behaviour, which is indistinguishable from the setting working.

`ask-intelligent` is not incidental: it is the resolver's default, the `standard` and `custom` rigor-profile mapping, and the branch the wave skills key off. Only the docs were left behind when it landed.

## What changed

- `docs/reference/global-config.md`, `docs/guides/configuring-doc-density.md` — document `ask-intelligent`, describe what it does (scoped trigger-based menu; only Tier-2 items matching a fired trigger are shown), and mark it as the fresh-install default.
- `nWave/skills/nw-density-resolution-contract/SKILL.md` — add it to the contract's value list, in EARS form.
- `scripts/shared/density_config.py` — reject an unrecognised `expansion_prompt` with an error naming the accepted set.
- `tests/des/unit/shared/test_density_config.py` — three tests covering the rejection, the error content, and that a known value without a density is still accepted.

Split into two commits: `docs(density)` for the documentation, `fix(density)` for the validation.

## Where the validation lives, and why

`resolve_density` has two branches that read `expansion_prompt` and three that never touch it. Validating inside a branch would leave a config carrying *only* `expansion_prompt` unvalidated — which is precisely the reported failure shape. So the raw key is checked up front, whenever present, before the cascade.

## What this PR deliberately does not decide

Three questions in #84 are genuine product forks and are left open rather than guessed at:

- **Whether plain `ask` is superseded by `ask-intelligent`.** Not removed, not deprecated — documented as a peer value.
- **Whether a valid `expansion_prompt` set without a density should take effect.** It is still ignored by the cascade; it now merely validates. Making it resolve would be a behaviour change.
- **Whether `documentation.default_expansions`** — documented as applying "when prompt mode is `ask`" — also applies under `ask-intelligent`.

Each needs an answer from someone who knows the intent behind Decision 4. Say which way they go and the follow-up is small.

## Test plan

- `./.venv/bin/python -m pytest tests/des/unit/shared -q` — 9 passed at head. Reverting `density_config.py` alone puts the two new validation tests back to red, which is the RED proof.
- All 16 density tests (unit + doctor) pass.
- Full `tests/des/unit` shows no regression against the pre-existing baseline in the same environment.
- Not tested: the upgrade path. `_write_density_choice` uses `setdefault`, so an already-written config keeps its existing value; since `ask`, `smart` and `always-skip` all remain accepted, no existing install starts failing.

## Focus areas

- **`resolve_density` now raises where it previously returned.** Callers are `nwave_ai/doctor/checks/density.py` and the wave-skill harness. The doctor's own tests pass unchanged, but I did not audit whether it renders the `ValueError` as a friendly diagnostic or lets it escape as a traceback — worth a glance, since surfacing a stack trace to a user with a typo'd config would trade one bad experience for another.
- **Write-time vs resolve-time.** Validation is at the resolver; `nwave_ai/cli.py` `_write_density_choice` is not routed through it. Deliberate, to keep the change small, but a maintainer may want both.
- **The accepted set now exists in four places** — the tuple in code plus three prose lists. A comment on the tuple points at the doc paths, which is a mitigation and not a guarantee; a sixth value would drift again. A generated list would fix this properly.

## Risk / rollback

Blast radius: any config with an `expansion_prompt` value outside the accepted set now fails loudly at resolve time instead of silently defaulting. That is the intended change, and it is the only behavioural difference.

Revert with `git revert` of the `fix(density)` commit; the `docs(density)` commit is independently safe to keep.

Closes #84
