### PR TITLE
fix(packaging): ship outcomes schema.json in the wheel; make des-* console scripts work when installed

### DIFF
--- a/docs/reference/outcomes-cli.md
+++ b/docs/reference/outcomes-cli.md
@@ -263,7 +263,7 @@ nwave-ai outcomes check-delta docs/feature/my-feature/feature-delta.md
 
 ## Registry schema
 
-The registry file is YAML matching the JSON Schema at `docs/product/outcomes/schema.json` (draft-07). Each entry is one element of the top-level `outcomes:` list.
+The registry file is YAML matching the JSON Schema packaged at `nwave_ai/outcomes/schema.json` (draft-07). Each entry is one element of the top-level `outcomes:` list.
 
 ### Top-level structure
 
@@ -346,5 +346,5 @@ Threshold: ≥ 0.4 → Tier-2 fires.
 - **[Your First Outcome](../guides/outcomes-first-outcome/README.md)** — tutorial for new authors.
 - **[How to resolve a collision](../guides/howto-resolve-outcomes-collision.md)** — triage flagged candidates.
 - **[Why an outcomes registry?](../product/outcomes/README.md)** — design rationale and locked decisions.
-- **JSON Schema** — `docs/product/outcomes/schema.json`.
+- **JSON Schema** — `nwave_ai/outcomes/schema.json` (shipped as package data).
 - **Seeded registry** — `docs/product/outcomes/registry.yaml`.

--- a/nwave_ai/des_entry.py
+++ b/nwave_ai/des_entry.py
@@ -1,0 +1,74 @@
+"""Console-script shims for the des-* entry points.
+
+The DES runtime ships inside the wheel as installer payload at
+``nWave/lib/python/des`` (with imports rewritten to top-level ``des``), not
+as an importable site-packages package. Entry points that target
+``des.cli.*`` directly therefore crash with ``ModuleNotFoundError`` in any
+installed environment (pip/pipx/uv tool).
+
+These wrappers locate the payload — preferring the version-matched copy
+shipped next to this package, falling back to the nWave installer target at
+``~/.claude/lib/python`` — prepend it to ``sys.path``, and dispatch to the
+real ``des.cli.*`` main. This mirrors what the ``nWave/scripts/des/*`` shims
+do, but through the standard console-script mechanism so the PATH-visible
+commands actually work.
+"""
+
+from __future__ import annotations
+
+import sys
+from importlib import import_module
+from pathlib import Path
+
+
+def _payload_candidates() -> tuple[Path, ...]:
+    return (
+        # site-packages/nWave/lib/python — shipped in this wheel, version-matched
+        Path(__file__).resolve().parent.parent / "nWave" / "lib" / "python",
+        # nWave installer target (`nwave-ai install`)
+        Path.home() / ".claude" / "lib" / "python",
+    )
+
+
+def _locate_payload() -> Path | None:
+    for candidate in _payload_candidates():
+        if (candidate / "des" / "__init__.py").is_file():
+            return candidate
+    return None
+
+
+def _dispatch(module_name: str) -> int:
+    payload = _locate_payload()
+    if payload is None:
+        searched = ", ".join(str(c) for c in _payload_candidates())
+        sys.stderr.write(f"ERROR: DES runtime not found (searched: {searched})\n")
+        return 1
+    payload_str = str(payload)
+    if payload_str not in sys.path:
+        sys.path.insert(0, payload_str)
+    result = import_module(module_name).main()
+    return 0 if result is None else int(result)
+
+
+def log_phase() -> None:
+    raise SystemExit(_dispatch("des.cli.log_phase"))
+
+
+def commit() -> None:
+    raise SystemExit(_dispatch("des.cli.commit"))
+
+
+def init_log() -> None:
+    raise SystemExit(_dispatch("des.cli.init_log"))
+
+
+def verify_integrity() -> None:
+    raise SystemExit(_dispatch("des.cli.verify_deliver_integrity"))
+
+
+def roadmap() -> None:
+    raise SystemExit(_dispatch("des.cli.roadmap"))
+
+
+def health_check() -> None:
+    raise SystemExit(_dispatch("des.cli.health_check"))

--- a/nwave_ai/outcomes/application/registry_service.py
+++ b/nwave_ai/outcomes/application/registry_service.py
@@ -2,8 +2,8 @@
 and JSON Schema validation.
 
 Driving port: register / load. Drives the RegistryReader and
-RegistryWriter driven ports. Validates every outcome against
-docs/product/outcomes/schema.json before persistence (fail-fast on
+RegistryWriter driven ports. Validates every outcome against the
+packaged nwave_ai/outcomes/schema.json before persistence (fail-fast on
 malformed entries — protects the registry contract).
 """
 
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import json
 from functools import lru_cache
-from pathlib import Path
+from importlib.resources import files
 
 from jsonschema import Draft7Validator
 from jsonschema import ValidationError as JsonSchemaValidationError
@@ -24,13 +24,7 @@ from nwave_ai.outcomes.ports.registry_io import (  # noqa: TC001  # runtime DI
 )
 
 
-_SCHEMA_PATH = (
-    Path(__file__).resolve().parents[3]
-    / "docs"
-    / "product"
-    / "outcomes"
-    / "schema.json"
-)
+_SCHEMA_RESOURCE = files("nwave_ai.outcomes").joinpath("schema.json")
 
 
 class DuplicateOutcomeIdError(Exception):
@@ -51,7 +45,7 @@ class UnknownOutcomeIdError(Exception):
 
 @lru_cache(maxsize=1)
 def _load_validator() -> Draft7Validator:
-    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    schema = json.loads(_SCHEMA_RESOURCE.read_text(encoding="utf-8"))
     return Draft7Validator(schema)
 
 

--- a/nwave_ai/outcomes/schema.json
+++ b/nwave_ai/outcomes/schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://nwave.ai/schemas/outcome.json",
+  "title": "Outcome",
+  "description": "One registered outcome — a shipped capability identified by OUT-N. Mirrors nwave_ai.outcomes.domain.outcome.Outcome.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^OUT-[A-Z0-9]+$"
+    },
+    "kind": {
+      "type": "string",
+      "enum": ["specification", "operation", "invariant"]
+    },
+    "summary": {
+      "type": "string"
+    },
+    "feature": {
+      "type": "string"
+    },
+    "inputs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "shape": {"type": "string"}
+        },
+        "required": ["shape"],
+        "additionalProperties": false
+      }
+    },
+    "output": {
+      "type": "object",
+      "properties": {
+        "shape": {"type": "string"}
+      },
+      "required": ["shape"],
+      "additionalProperties": false
+    },
+    "keywords": {
+      "type": "array",
+      "maxItems": 6,
+      "items": {"type": "string"}
+    },
+    "artifact": {
+      "type": "string"
+    },
+    "related": {
+      "type": "array",
+      "items": {"type": "string", "pattern": "^OUT-[A-Z0-9]+$"}
+    },
+    "superseded_by": {
+      "type": ["string", "null"],
+      "pattern": "^OUT-[A-Z0-9]+$"
+    }
+  },
+  "required": [
+    "id",
+    "kind",
+    "summary",
+    "feature",
+    "inputs",
+    "output",
+    "keywords",
+    "artifact",
+    "related",
+    "superseded_by"
+  ],
+  "additionalProperties": false
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,12 +140,17 @@ Issues = "https://github.com/nWave-ai/nWave/issues"
 
 [project.scripts]
 nwave-ai = "nwave_ai.cli:main"
-des-log-phase = "des.cli.log_phase:main"
-des-commit = "des.cli.commit:main"
-des-init-log = "des.cli.init_log:main"
-des-verify-integrity = "des.cli.verify_deliver_integrity:main"
-des-roadmap = "des.cli.roadmap:main"
-des-health-check = "des.cli.health_check:main"
+# The DES runtime ships as payload at nWave/lib/python/des (top-level `des`
+# imports), not as an importable site-packages package. Direct des.cli.*
+# entry points therefore crash with ModuleNotFoundError in an installed
+# wheel — route through nwave_ai.des_entry, which puts the payload on
+# sys.path first.
+des-log-phase = "nwave_ai.des_entry:log_phase"
+des-commit = "nwave_ai.des_entry:commit"
+des-init-log = "nwave_ai.des_entry:init_log"
+des-verify-integrity = "nwave_ai.des_entry:verify_integrity"
+des-roadmap = "nwave_ai.des_entry:roadmap"
+des-health-check = "nwave_ai.des_entry:health_check"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/outcomes/unit/test_schema_validation.py
+++ b/tests/outcomes/unit/test_schema_validation.py
@@ -1,6 +1,6 @@
 """Unit test: JSON Schema validates registry entries.
 
-Loads docs/product/outcomes/schema.json (draft-07) and asserts:
+Loads the packaged nwave_ai/outcomes/schema.json (draft-07) and asserts:
 - a valid canonical entry passes
 - entries missing required fields fail
 - entries with invalid kind/id pattern fail
@@ -9,19 +9,17 @@ Loads docs/product/outcomes/schema.json (draft-07) and asserts:
 from __future__ import annotations
 
 import json
-from pathlib import Path
+from importlib.resources import files
 
 import pytest
 from jsonschema import Draft7Validator, ValidationError
 
 
-_SCHEMA_PATH = (
-    Path(__file__).parents[3] / "docs" / "product" / "outcomes" / "schema.json"
-)
+_SCHEMA_RESOURCE = files("nwave_ai.outcomes").joinpath("schema.json")
 
 
 def _load_schema() -> dict:
-    return json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    return json.loads(_SCHEMA_RESOURCE.read_text(encoding="utf-8"))
 
 
 def _valid_entry() -> dict:


### PR DESCRIPTION
## Summary

Two packaging defects make the v3.21.0 wheel partially unusable in any installed environment (pip / pipx / `uv tool install`). Both were hit in a real project on 2026-08-12; this PR fixes both, verified on a locally built wheel.

### Defect 1 — `nwave-ai outcomes register` always crashes (schema.json missing)

`nwave_ai/outcomes/application/registry_service.py` resolved the validator schema as:

```python
_SCHEMA_PATH = Path(__file__).resolve().parents[3] / "docs" / "product" / "outcomes" / "schema.json"
```

`parents[3]` from site-packages resolves to `site-packages/docs/product/outcomes/schema.json`, which never exists in an installed wheel, so every `outcomes register` dies with `FileNotFoundError`. Digging further: **the schema file was never committed anywhere in this repo** — `tests/outcomes/unit/test_schema_validation.py` points at the same repo path and had no file to load, so the whole schema-validation and registry-service test set fails even on a source checkout.

**Fix:**
- Author `nwave_ai/outcomes/schema.json` as package data, written to the exact contract the unit tests and the `Outcome` domain model pin: `^OUT-[A-Z0-9]+$` id pattern, `kind` enum (`specification` / `operation` / `invariant`), `inputs` minItems 1 with required nested `shape`, `output.shape` required, `keywords` maxItems 6, `related` / nullable `superseded_by`, all 10 fields required, `additionalProperties: false`. Empty strings stay schema-valid on `summary`/`feature`/`artifact` — the CLI acceptance test registers with those omitted and expects the *duplicate-id* error, not a schema error.
- Load it via `importlib.resources.files("nwave_ai.outcomes")` — no filesystem-layout assumptions, works installed and from source.
- Point the unit test at the packaged resource.

### Defect 2 — all six `des-*` console scripts crash with `ModuleNotFoundError: No module named 'des'`

`[project.scripts]` targets `des.cli.*`, but the DES runtime ships only as installer payload at `nWave/lib/python/des` (imports rewritten to top-level `des` by `scripts/build_dist.py`) — it is not importable from site-packages. The PATH-visible `.exe` shims generated from those entry points shadow the working `nWave/scripts/des/*` shims and always crash.

**Fix:** route the entry points through a new `nwave_ai/des_entry.py`, which locates the payload (wheel-local `site-packages/nWave/lib/python` first — version-matched and always present; `~/.claude/lib/python` installer target as fallback), prepends it to `sys.path`, and dispatches to the real `des.cli.*` main. Same mechanism the working `nWave/scripts/des/*` shims use, applied to the console scripts. No second copy of `des` is shipped (avoids the double-distribution bloat CLAUDE.md warns about — and note hatchling silently deduplicates two force-include keys that normalize to the same source, so the "map it twice" approach doesn't work anyway).

## Test results

`tests/outcomes` + `tests/regression/test_issue_60_jsonschema_runtime_dep.py`: **53/54 pass** (before: the entire schema-validation, registry-service, and US-1 register acceptance set failed on the missing schema).

The one remaining failure, `test_seed_registry.py`, is pre-existing and orthogonal: it asserts the seeded production registry at `docs/product/outcomes/registry.yaml` (OUT-E1..E5 + OUT-FORMAT, migrated from a spike registry), which — like the schema — was never committed to this repo and whose curated content only the maintainers can restore.

## Wheel verification

Built the wheel locally (after staging `lib/python/des` via `scripts/build_dist.py`, as the release pipeline does) and installed it into a clean venv:

- `des-init-log --project-dir . --feature-id smoke` → `Created execution-log.json` (schema 5.0) ✔
- `nwave-ai outcomes register --id OUT-1 ...` → `REGISTERED: OUT-1`, canonical-key-order YAML written ✔
- Wheel contains `nwave_ai/outcomes/schema.json` and `nWave/lib/python/des/` payload; no stray top-level `des/` ✔

## Environment

nwave-ai 3.21.0 via `uv tool install`, Windows 11, Python 3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Kfo2yF66iXwXFXuUTrwYC
