### PR TITLE
Fix broken raw.githubusercontent.com links with stray closing brace

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ nWave runs inside [Claude Code](https://claude.com/product/claude-code). It brea
 **Requirements**: Python 3.10+ and Claude Code.
 
 ```bash
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main}/scripts/install/install.sh)"
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main/scripts/install/install.sh)"
 ```
 
 This installs the `nwave-ai` CLI and wires nWave into Claude Code in one step. It uses [uv](https://docs.astral.sh/uv/) when available (recommended); [pipx](https://pipx.pypa.io/) is supported but not recommended. Restart Claude Code when it finishes.

--- a/docs/guides/how-to-deliver-wave-step-scenario-mapping/README.md
+++ b/docs/guides/how-to-deliver-wave-step-scenario-mapping/README.md
@@ -12,7 +12,7 @@ Successfully execute a DELIVER wave where each roadmap step implements exactly o
 
 You will need:
 - A completed acceptance test file with scenarios (from DISTILL wave)
-- The nWave framework installed via `sh -c "$(curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main}/scripts/install/install.sh)"`
+- The nWave framework installed via `sh -c "$(curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main/scripts/install/install.sh)"`
 - A project with user story identification (e.g., `us001`, `us002`)
 
 ## Step 1: Count Your Acceptance Test Scenarios

--- a/docs/guides/installation-guide/README.md
+++ b/docs/guides/installation-guide/README.md
@@ -46,7 +46,7 @@ pipx ensurepath
 ### One-line install
 
 ```bash
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main}/scripts/install/install.sh)"
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main/scripts/install/install.sh)"
 ```
 
 This bootstrap script picks a Python application installer, installs the
@@ -102,17 +102,17 @@ With the `sh -c "$(curl ...)"` form, put script options after a `--` separator:
 
 ```bash
 # Force pipx even if uv is present (explicit consent — no prompt)
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main}/scripts/install/install.sh)" -- --tool pipx
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main/scripts/install/install.sh)" -- --tool pipx
 
 # Accept the pipx fallback without prompting (CI / non-interactive)
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main}/scripts/install/install.sh)" -- --yes
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main/scripts/install/install.sh)" -- --yes
 ```
 
 The environment-variable form works too and needs no separator:
 
 ```bash
 NWAVE_INSTALLER_TOOL=pipx NWAVE_ASSUME_YES=1 \
-  sh -c "$(curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main}/scripts/install/install.sh)"
+  sh -c "$(curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main/scripts/install/install.sh)"
 ```
 
 ### Exit codes

--- a/docs/guides/team-rollout.md
+++ b/docs/guides/team-rollout.md
@@ -28,7 +28,7 @@ If you are the first developer on the project:
 
 ```bash
 # 1. Install nWave (installs the CLI, deploys agents, runs doctor)
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main}/scripts/install/install.sh)"
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main/scripts/install/install.sh)"
 
 # 2. Run your first wave on a real feature
 # (inside Claude Code)
@@ -59,7 +59,7 @@ git clone <repo-url>
 cd <repo>
 
 # 2. Install nWave on your machine
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main}/scripts/install/install.sh)"
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main/scripts/install/install.sh)"
 
 # 3. Verify your install is healthy
 nwave-ai doctor
@@ -189,7 +189,7 @@ Use this format when introducing nWave to a team that has not used it before.
 
 | Time | Activity |
 |------|----------|
-| 0-15 min | Everyone installs: `sh -c "$(curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main}/scripts/install/install.sh)"` |
+| 0-15 min | Everyone installs: `sh -c "$(curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main/scripts/install/install.sh)"` |
 | 15-25 min | Facilitator runs `/nw-discuss` on the chosen feature, narrates decisions aloud |
 | 25-35 min | Team reviews the `docs/feature/` artifact together, edits if needed, commits |
 | 35-50 min | Facilitator runs `/nw-distill`, team reviews acceptance tests |

--- a/docs/guides/tutorial-debugging/README.md
+++ b/docs/guides/tutorial-debugging/README.md
@@ -12,7 +12,7 @@
 Run from a directory where you want the tutorial project created (e.g. `~/projects`):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main}/docs/guides/tutorial-debugging/setup.py | python3
+curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main/docs/guides/tutorial-debugging/setup.py | python3
 ```
 
 Prefer to read first? See [manual-setup.md](./manual-setup.md).

--- a/docs/guides/tutorial-documentation/README.md
+++ b/docs/guides/tutorial-documentation/README.md
@@ -12,7 +12,7 @@
 Run from a directory where you want the tutorial project created (e.g. `~/projects`):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main}/docs/guides/tutorial-documentation/setup.py | python3
+curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main/docs/guides/tutorial-documentation/setup.py | python3
 ```
 
 Prefer to read first? See [manual-setup.md](./manual-setup.md).

--- a/docs/guides/tutorial-first-delivery/README.md
+++ b/docs/guides/tutorial-first-delivery/README.md
@@ -13,7 +13,7 @@
 Run from a directory where you want the tutorial project created (e.g. `~/projects`):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main}/docs/guides/tutorial-first-delivery/setup.py | python3
+curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main/docs/guides/tutorial-first-delivery/setup.py | python3
 ```
 
 Prefer to read first? See [manual-setup.md](./manual-setup.md).

--- a/docs/guides/tutorial-first-feature/README.md
+++ b/docs/guides/tutorial-first-feature/README.md
@@ -6,7 +6,7 @@ Learn nWave by building a complete feature end-to-end.
 
 **Prerequisites**:
 - **Platform**: Linux, macOS, or Windows (WSL2 required)
-- nWave installed: `sh -c "$(curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main}/scripts/install/install.sh)"` — in terminal, not Claude Code
+- nWave installed: `sh -c "$(curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main/scripts/install/install.sh)"` — in terminal, not Claude Code
 - Claude Code reopened after install
 - A Python project with pytest
 - Basic TDD familiarity

--- a/docs/guides/tutorial-hello-nwave/README.md
+++ b/docs/guides/tutorial-hello-nwave/README.md
@@ -7,7 +7,7 @@ Build a working, tested feature from scratch using nWave. Three commands, five m
 
 **Prerequisites**:
 - **Platform**: Linux, macOS, or Windows (WSL2 required)
-- nWave installed — `sh -c "$(curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main}/scripts/install/install.sh)"` — in your terminal, not Claude Code
+- nWave installed — `sh -c "$(curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main/scripts/install/install.sh)"` — in your terminal, not Claude Code
 - Claude Code open in an empty Python project with `pytest` available
 - Use a permanent directory (not `/tmp`) — later tutorials build on this project
 

--- a/docs/guides/tutorial-mutation-testing/README.md
+++ b/docs/guides/tutorial-mutation-testing/README.md
@@ -12,7 +12,7 @@
 Run from a directory where you want the tutorial project created (e.g. `~/projects`):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main}/docs/guides/tutorial-mutation-testing/setup.py | python3
+curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main/docs/guides/tutorial-mutation-testing/setup.py | python3
 ```
 
 Prefer to read first? See [manual-setup.md](./manual-setup.md).

--- a/docs/guides/tutorial-refactoring/README.md
+++ b/docs/guides/tutorial-refactoring/README.md
@@ -12,7 +12,7 @@
 Run from a directory where you want the tutorial project created (e.g. `~/projects`):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main}/docs/guides/tutorial-refactoring/setup.py | python3
+curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main/docs/guides/tutorial-refactoring/setup.py | python3
 ```
 
 Prefer to read first? See [manual-setup.md](./manual-setup.md).

--- a/docs/guides/tutorial-writing-tests/README.md
+++ b/docs/guides/tutorial-writing-tests/README.md
@@ -12,7 +12,7 @@
 Run from a directory where you want the tutorial project created (e.g. `~/projects`):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main}/docs/guides/tutorial-writing-tests/setup.py | python3
+curl -fsSL https://raw.githubusercontent.com/nWave-ai/nWave/main/docs/guides/tutorial-writing-tests/setup.py | python3
 ```
 
 Prefer to read first? See [manual-setup.md](./manual-setup.md).


### PR DESCRIPTION
Several markdown docs had install/setup links built as .../nWave/main}/... — the stray } made the raw.githubusercontent.com URL invalid. Removed the extra brace across all affected files.